### PR TITLE
feat(providers): implement ProviderContext for portable storage directory

### DIFF
--- a/llama_stack/cli/stack/run.py
+++ b/llama_stack/cli/stack/run.py
@@ -59,6 +59,11 @@ class StackRun(Subcommand):
             help="Image Type used during the build. This can be either conda or container or venv.",
             choices=[e.value for e in ImageType],
         )
+        self.parser.add_argument(
+            "--storage-directory",
+            type=str,
+            help="Directory to use for provider state (overrides environment variable and default).",
+        )
 
     # If neither image type nor image name is provided, but at the same time
     # the current environment has conda breadcrumbs, then assume what the user
@@ -117,6 +122,9 @@ class StackRun(Subcommand):
             config = parse_and_maybe_upgrade_config(config_dict)
         except AttributeError as e:
             self.parser.error(f"failed to parse config file '{config_file}':\n {e}")
+
+        # Pass the CLI storage directory option to run_config for resolver use
+        config.storage_dir = args.storage_directory
 
         image_type, image_name = self._get_image_type_and_name(args)
 

--- a/llama_stack/distribution/datatypes.py
+++ b/llama_stack/distribution/datatypes.py
@@ -317,6 +317,11 @@ a default SQLite store will be used.""",
         description="Path to directory containing external provider implementations. The providers code and dependencies must be installed on the system.",
     )
 
+    storage_dir: str | None = Field(
+        default=None,
+        description="Directory to use for provider state. Can be set by CLI, environment variable and default to the distribution directory",
+    )
+
 
 class BuildConfig(BaseModel):
     version: str = LLAMA_STACK_BUILD_CONFIG_VERSION

--- a/llama_stack/distribution/inspect.py
+++ b/llama_stack/distribution/inspect.py
@@ -24,7 +24,7 @@ class DistributionInspectConfig(BaseModel):
     run_config: StackRunConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(context, config, deps):
     impl = DistributionInspectImpl(config, deps)
     await impl.initialize()
     return impl

--- a/llama_stack/distribution/providers.py
+++ b/llama_stack/distribution/providers.py
@@ -23,7 +23,7 @@ class ProviderImplConfig(BaseModel):
     run_config: StackRunConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(context, config, deps):
     impl = ProviderImpl(config, deps)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/datatypes.py
+++ b/llama_stack/providers/datatypes.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
@@ -161,7 +163,7 @@ If a provider depends on other providers, the dependencies MUST NOT specify a co
         description="""
 Fully-qualified name of the module to import. The module is expected to have:
 
- - `get_provider_impl(config, deps)`: returns the local implementation
+ - `get_provider_impl(context, config, deps)`: returns the local implementation
 """,
     )
     provider_data_validator: str | None = Field(
@@ -232,3 +234,19 @@ class HealthStatus(str, Enum):
 
 
 HealthResponse = dict[str, Any]
+
+
+@dataclass
+class ProviderContext:
+    """
+    Runtime context for provider instantiation.
+
+    This object is constructed by the Llama Stack runtime and injected into every provider.
+    It contains environment- and deployment-specific information that should not be part of the static config file.
+
+    Attributes:
+        storage_dir (Path): Directory for provider state (persistent or ephemeral),
+            resolved from CLI option, environment variable, or default distribution directory.
+    """
+
+    storage_dir: Path

--- a/llama_stack/providers/inline/agents/meta_reference/__init__.py
+++ b/llama_stack/providers/inline/agents/meta_reference/__init__.py
@@ -7,14 +7,16 @@
 from typing import Any
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import MetaReferenceAgentsImplConfig
 
 
-async def get_provider_impl(config: MetaReferenceAgentsImplConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: MetaReferenceAgentsImplConfig, deps: dict[Api, Any]):
     from .agents import MetaReferenceAgentsImpl
 
     impl = MetaReferenceAgentsImpl(
+        context,
         config,
         deps[Api.inference],
         deps[Api.vector_io],

--- a/llama_stack/providers/inline/agents/meta_reference/agents.py
+++ b/llama_stack/providers/inline/agents/meta_reference/agents.py
@@ -37,6 +37,7 @@ from llama_stack.apis.inference import (
 from llama_stack.apis.safety import Safety
 from llama_stack.apis.tools import ToolGroups, ToolRuntime
 from llama_stack.apis.vector_io import VectorIO
+from llama_stack.providers.datatypes import ProviderContext
 from llama_stack.providers.utils.kvstore import InmemoryKVStoreImpl, kvstore_impl
 from llama_stack.providers.utils.pagination import paginate_records
 
@@ -51,6 +52,7 @@ logger = logging.getLogger()
 class MetaReferenceAgentsImpl(Agents):
     def __init__(
         self,
+        context: ProviderContext,
         config: MetaReferenceAgentsImplConfig,
         inference_api: Inference,
         vector_io_api: VectorIO,
@@ -58,6 +60,7 @@ class MetaReferenceAgentsImpl(Agents):
         tool_runtime_api: ToolRuntime,
         tool_groups_api: ToolGroups,
     ):
+        self.context = context
         self.config = config
         self.inference_api = inference_api
         self.vector_io_api = vector_io_api

--- a/llama_stack/providers/inline/datasetio/localfs/__init__.py
+++ b/llama_stack/providers/inline/datasetio/localfs/__init__.py
@@ -6,15 +6,18 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
+
 from .config import LocalFSDatasetIOConfig
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: LocalFSDatasetIOConfig,
     _deps: dict[str, Any],
 ):
     from .datasetio import LocalFSDatasetIOImpl
 
-    impl = LocalFSDatasetIOImpl(config)
+    impl = LocalFSDatasetIOImpl(context, config)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/datasetio/localfs/datasetio.py
+++ b/llama_stack/providers/inline/datasetio/localfs/datasetio.py
@@ -10,7 +10,7 @@ import pandas
 from llama_stack.apis.common.responses import PaginatedResponse
 from llama_stack.apis.datasetio import DatasetIO
 from llama_stack.apis.datasets import Dataset
-from llama_stack.providers.datatypes import DatasetsProtocolPrivate
+from llama_stack.providers.datatypes import DatasetsProtocolPrivate, ProviderContext
 from llama_stack.providers.utils.datasetio.url_utils import get_dataframe_from_uri
 from llama_stack.providers.utils.kvstore import kvstore_impl
 from llama_stack.providers.utils.pagination import paginate_records
@@ -53,7 +53,8 @@ class PandasDataframeDataset:
 
 
 class LocalFSDatasetIOImpl(DatasetIO, DatasetsProtocolPrivate):
-    def __init__(self, config: LocalFSDatasetIOConfig) -> None:
+    def __init__(self, context: ProviderContext, config: LocalFSDatasetIOConfig) -> None:
+        self.context = context
         self.config = config
         # local registry for keeping track of datasets within the provider
         self.dataset_infos = {}

--- a/llama_stack/providers/inline/eval/meta_reference/__init__.py
+++ b/llama_stack/providers/inline/eval/meta_reference/__init__.py
@@ -6,11 +6,13 @@
 from typing import Any
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import MetaReferenceEvalConfig
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: MetaReferenceEvalConfig,
     deps: dict[Api, Any],
 ):

--- a/llama_stack/providers/inline/inference/meta_reference/__init__.py
+++ b/llama_stack/providers/inline/inference/meta_reference/__init__.py
@@ -6,15 +6,14 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
+
 from .config import MetaReferenceInferenceConfig
 
 
-async def get_provider_impl(
-    config: MetaReferenceInferenceConfig,
-    _deps: dict[str, Any],
-):
+async def get_provider_impl(context: ProviderContext, config: MetaReferenceInferenceConfig, _deps: dict[str, Any]):
     from .inference import MetaReferenceInferenceImpl
 
-    impl = MetaReferenceInferenceImpl(config)
+    impl = MetaReferenceInferenceImpl(context, config)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/inference/meta_reference/inference.py
+++ b/llama_stack/providers/inline/inference/meta_reference/inference.py
@@ -50,7 +50,7 @@ from llama_stack.models.llama.llama4.chat_format import ChatFormat as Llama4Chat
 from llama_stack.models.llama.llama4.tokenizer import Tokenizer as Llama4Tokenizer
 from llama_stack.models.llama.sku_list import resolve_model
 from llama_stack.models.llama.sku_types import ModelFamily
-from llama_stack.providers.datatypes import ModelsProtocolPrivate
+from llama_stack.providers.datatypes import ModelsProtocolPrivate, ProviderContext
 from llama_stack.providers.utils.inference.embedding_mixin import (
     SentenceTransformerEmbeddingMixin,
 )
@@ -89,7 +89,8 @@ class MetaReferenceInferenceImpl(
     Inference,
     ModelsProtocolPrivate,
 ):
-    def __init__(self, config: MetaReferenceInferenceConfig) -> None:
+    def __init__(self, context: ProviderContext, config: MetaReferenceInferenceConfig) -> None:
+        self.context = context
         self.config = config
         self.model_id = None
         self.llama_model = None

--- a/llama_stack/providers/inline/inference/sentence_transformers/__init__.py
+++ b/llama_stack/providers/inline/inference/sentence_transformers/__init__.py
@@ -6,12 +6,14 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
 from llama_stack.providers.inline.inference.sentence_transformers.config import (
     SentenceTransformersInferenceConfig,
 )
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: SentenceTransformersInferenceConfig,
     _deps: dict[str, Any],
 ):

--- a/llama_stack/providers/inline/inference/vllm/__init__.py
+++ b/llama_stack/providers/inline/inference/vllm/__init__.py
@@ -6,12 +6,14 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
+
 from .config import VLLMConfig
 
 
-async def get_provider_impl(config: VLLMConfig, _deps: dict[str, Any]):
+async def get_provider_impl(context: ProviderContext, config: VLLMConfig, deps: dict[str, Any]):
     from .vllm import VLLMInferenceImpl
 
-    impl = VLLMInferenceImpl(config)
+    impl = VLLMInferenceImpl(context, config)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/post_training/torchtune/__init__.py
+++ b/llama_stack/providers/inline/post_training/torchtune/__init__.py
@@ -7,6 +7,7 @@
 from typing import Any
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import TorchtunePostTrainingConfig
 
@@ -14,12 +15,14 @@ from .config import TorchtunePostTrainingConfig
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: TorchtunePostTrainingConfig,
     deps: dict[Api, Any],
 ):
     from .post_training import TorchtunePostTrainingImpl
 
     impl = TorchtunePostTrainingImpl(
+        context,
         config,
         deps[Api.datasetio],
         deps[Api.datasets],

--- a/llama_stack/providers/inline/post_training/torchtune/post_training.py
+++ b/llama_stack/providers/inline/post_training/torchtune/post_training.py
@@ -20,6 +20,7 @@ from llama_stack.apis.post_training import (
     PostTrainingJobStatusResponse,
     TrainingConfig,
 )
+from llama_stack.providers.datatypes import ProviderContext
 from llama_stack.providers.inline.post_training.torchtune.config import (
     TorchtunePostTrainingConfig,
 )
@@ -42,10 +43,12 @@ _JOB_TYPE_SUPERVISED_FINE_TUNE = "supervised-fine-tune"
 class TorchtunePostTrainingImpl:
     def __init__(
         self,
+        context: ProviderContext,
         config: TorchtunePostTrainingConfig,
         datasetio_api: DatasetIO,
         datasets: Datasets,
     ) -> None:
+        self.context = context
         self.config = config
         self.datasetio_api = datasetio_api
         self.datasets_api = datasets

--- a/llama_stack/providers/inline/safety/code_scanner/__init__.py
+++ b/llama_stack/providers/inline/safety/code_scanner/__init__.py
@@ -6,12 +6,14 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
+
 from .config import CodeScannerConfig
 
 
-async def get_provider_impl(config: CodeScannerConfig, deps: dict[str, Any]):
+async def get_provider_impl(context: ProviderContext, config: CodeScannerConfig, deps: dict[str, Any]):
     from .code_scanner import MetaReferenceCodeScannerSafetyImpl
 
-    impl = MetaReferenceCodeScannerSafetyImpl(config, deps)
+    impl = MetaReferenceCodeScannerSafetyImpl(context, config, deps)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
+++ b/llama_stack/providers/inline/safety/code_scanner/code_scanner.py
@@ -15,6 +15,7 @@ from llama_stack.apis.safety import (
     ViolationLevel,
 )
 from llama_stack.apis.shields import Shield
+from llama_stack.providers.datatypes import ProviderContext
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
 )
@@ -30,8 +31,10 @@ ALLOWED_CODE_SCANNER_MODEL_IDS = [
 
 
 class MetaReferenceCodeScannerSafetyImpl(Safety):
-    def __init__(self, config: CodeScannerConfig, deps) -> None:
+    def __init__(self, context: ProviderContext, config: CodeScannerConfig, deps) -> None:
+        self.context = context
         self.config = config
+        self.deps = deps
 
     async def initialize(self) -> None:
         pass

--- a/llama_stack/providers/inline/safety/llama_guard/__init__.py
+++ b/llama_stack/providers/inline/safety/llama_guard/__init__.py
@@ -6,14 +6,16 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
+
 from .config import LlamaGuardConfig
 
 
-async def get_provider_impl(config: LlamaGuardConfig, deps: dict[str, Any]):
+async def get_provider_impl(context: ProviderContext, config: LlamaGuardConfig, deps: dict[str, Any]):
     from .llama_guard import LlamaGuardSafetyImpl
 
     assert isinstance(config, LlamaGuardConfig), f"Unexpected config type: {type(config)}"
 
-    impl = LlamaGuardSafetyImpl(config, deps)
+    impl = LlamaGuardSafetyImpl(context, config, deps)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
+++ b/llama_stack/providers/inline/safety/llama_guard/llama_guard.py
@@ -24,7 +24,7 @@ from llama_stack.apis.shields import Shield
 from llama_stack.distribution.datatypes import Api
 from llama_stack.models.llama.datatypes import Role
 from llama_stack.models.llama.sku_types import CoreModelId
-from llama_stack.providers.datatypes import ShieldsProtocolPrivate
+from llama_stack.providers.datatypes import ProviderContext, ShieldsProtocolPrivate
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
 )
@@ -130,7 +130,8 @@ PROMPT_TEMPLATE = Template(f"{PROMPT_TASK}{SAFETY_CATEGORIES}{PROMPT_CONVERSATIO
 
 
 class LlamaGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
-    def __init__(self, config: LlamaGuardConfig, deps) -> None:
+    def __init__(self, context: ProviderContext, config: LlamaGuardConfig, deps) -> None:
+        self.context = context
         self.config = config
         self.inference_api = deps[Api.inference]
 

--- a/llama_stack/providers/inline/safety/prompt_guard/__init__.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/__init__.py
@@ -6,12 +6,14 @@
 
 from typing import Any
 
+from llama_stack.providers.datatypes import ProviderContext
+
 from .config import PromptGuardConfig
 
 
-async def get_provider_impl(config: PromptGuardConfig, deps: dict[str, Any]):
+async def get_provider_impl(context: ProviderContext, config: PromptGuardConfig, deps: dict[str, Any]):
     from .prompt_guard import PromptGuardSafetyImpl
 
-    impl = PromptGuardSafetyImpl(config, deps)
+    impl = PromptGuardSafetyImpl(context, config, deps)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -19,7 +19,7 @@ from llama_stack.apis.safety import (
 )
 from llama_stack.apis.shields import Shield
 from llama_stack.distribution.utils.model_utils import model_local_dir
-from llama_stack.providers.datatypes import ShieldsProtocolPrivate
+from llama_stack.providers.datatypes import ProviderContext, ShieldsProtocolPrivate
 from llama_stack.providers.utils.inference.prompt_adapter import (
     interleaved_content_as_str,
 )
@@ -32,8 +32,10 @@ PROMPT_GUARD_MODEL = "Prompt-Guard-86M"
 
 
 class PromptGuardSafetyImpl(Safety, ShieldsProtocolPrivate):
-    def __init__(self, config: PromptGuardConfig, _deps) -> None:
+    def __init__(self, context: ProviderContext, config: PromptGuardConfig, _deps) -> None:
+        self.context = context
         self.config = config
+        self.deps = _deps
 
     async def initialize(self) -> None:
         model_dir = model_local_dir(PROMPT_GUARD_MODEL)

--- a/llama_stack/providers/inline/scoring/basic/__init__.py
+++ b/llama_stack/providers/inline/scoring/basic/__init__.py
@@ -6,17 +6,20 @@
 from typing import Any
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import BasicScoringConfig
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: BasicScoringConfig,
     deps: dict[Api, Any],
 ):
     from .scoring import BasicScoringImpl
 
     impl = BasicScoringImpl(
+        context,
         config,
         deps[Api.datasetio],
         deps[Api.datasets],

--- a/llama_stack/providers/inline/scoring/basic/scoring.py
+++ b/llama_stack/providers/inline/scoring/basic/scoring.py
@@ -15,7 +15,7 @@ from llama_stack.apis.scoring import (
 )
 from llama_stack.apis.scoring_functions import ScoringFn, ScoringFnParams
 from llama_stack.distribution.datatypes import Api
-from llama_stack.providers.datatypes import ScoringFunctionsProtocolPrivate
+from llama_stack.providers.datatypes import ProviderContext, ScoringFunctionsProtocolPrivate
 from llama_stack.providers.utils.common.data_schema_validator import (
     get_valid_schemas,
     validate_dataset_schema,
@@ -49,10 +49,12 @@ class BasicScoringImpl(
 ):
     def __init__(
         self,
+        context: ProviderContext,
         config: BasicScoringConfig,
         datasetio_api: DatasetIO,
         datasets_api: Datasets,
     ) -> None:
+        self.context = context
         self.config = config
         self.datasetio_api = datasetio_api
         self.datasets_api = datasets_api

--- a/llama_stack/providers/inline/scoring/braintrust/__init__.py
+++ b/llama_stack/providers/inline/scoring/braintrust/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import BraintrustScoringConfig
 
@@ -17,6 +18,7 @@ class BraintrustProviderDataValidator(BaseModel):
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: BraintrustScoringConfig,
     deps: dict[Api, Any],
 ):

--- a/llama_stack/providers/inline/scoring/llm_as_judge/__init__.py
+++ b/llama_stack/providers/inline/scoring/llm_as_judge/__init__.py
@@ -6,11 +6,13 @@
 from typing import Any
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import LlmAsJudgeScoringConfig
 
 
 async def get_provider_impl(
+    context: ProviderContext,
     config: LlmAsJudgeScoringConfig,
     deps: dict[Api, Any],
 ):

--- a/llama_stack/providers/inline/telemetry/meta_reference/__init__.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/__init__.py
@@ -7,15 +7,16 @@
 from typing import Any
 
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 
 from .config import TelemetryConfig, TelemetrySink
 
 __all__ = ["TelemetryConfig", "TelemetrySink"]
 
 
-async def get_provider_impl(config: TelemetryConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: TelemetryConfig, deps: dict[Api, Any]):
     from .telemetry import TelemetryAdapter
 
-    impl = TelemetryAdapter(config, deps)
+    impl = TelemetryAdapter(context, config, deps)
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
+++ b/llama_stack/providers/inline/telemetry/meta_reference/telemetry.py
@@ -36,6 +36,7 @@ from llama_stack.apis.telemetry import (
     UnstructuredLogEvent,
 )
 from llama_stack.distribution.datatypes import Api
+from llama_stack.providers.datatypes import ProviderContext
 from llama_stack.providers.inline.telemetry.meta_reference.console_span_processor import (
     ConsoleSpanProcessor,
 )
@@ -45,7 +46,7 @@ from llama_stack.providers.inline.telemetry.meta_reference.sqlite_span_processor
 from llama_stack.providers.utils.telemetry.dataset_mixin import TelemetryDatasetMixin
 from llama_stack.providers.utils.telemetry.sqlite_trace_store import SQLiteTraceStore
 
-from .config import TelemetryConfig, TelemetrySink
+from .config import TelemetrySink
 
 _GLOBAL_STORAGE: dict[str, dict[str | int, Any]] = {
     "active_spans": {},
@@ -63,8 +64,10 @@ def is_tracing_enabled(tracer):
 
 
 class TelemetryAdapter(TelemetryDatasetMixin, Telemetry):
-    def __init__(self, config: TelemetryConfig, deps: dict[Api, Any]) -> None:
+    def __init__(self, context: ProviderContext, config, deps):
+        self.context = context
         self.config = config
+        self.deps = deps
         self.datasetio_api = deps.get(Api.datasetio)
         self.meter = None
 

--- a/llama_stack/providers/inline/tool_runtime/rag/__init__.py
+++ b/llama_stack/providers/inline/tool_runtime/rag/__init__.py
@@ -6,12 +6,12 @@
 
 from typing import Any
 
-from llama_stack.providers.datatypes import Api
+from llama_stack.providers.datatypes import Api, ProviderContext
 
 from .config import RagToolRuntimeConfig
 
 
-async def get_provider_impl(config: RagToolRuntimeConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: RagToolRuntimeConfig, deps: dict[Api, Any]):
     from .memory import MemoryToolRuntimeImpl
 
     impl = MemoryToolRuntimeImpl(config, deps[Api.vector_io], deps[Api.inference])

--- a/llama_stack/providers/inline/vector_io/chroma/__init__.py
+++ b/llama_stack/providers/inline/vector_io/chroma/__init__.py
@@ -6,16 +6,17 @@
 
 from typing import Any
 
-from llama_stack.providers.datatypes import Api
+from llama_stack.providers.datatypes import Api, ProviderContext
 
 from .config import ChromaVectorIOConfig
 
 
-async def get_provider_impl(config: ChromaVectorIOConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: ChromaVectorIOConfig, deps: dict[Api, Any]):
     from llama_stack.providers.remote.vector_io.chroma.chroma import (
         ChromaVectorIOAdapter,
     )
 
+    # Pass config directly since ChromaVectorIOAdapter doesn't accept context
     impl = ChromaVectorIOAdapter(config, deps[Api.inference])
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/vector_io/faiss/__init__.py
+++ b/llama_stack/providers/inline/vector_io/faiss/__init__.py
@@ -6,16 +6,16 @@
 
 from typing import Any
 
-from llama_stack.providers.datatypes import Api
+from llama_stack.providers.datatypes import Api, ProviderContext
 
 from .config import FaissVectorIOConfig
 
 
-async def get_provider_impl(config: FaissVectorIOConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: FaissVectorIOConfig, deps: dict[Api, Any]):
     from .faiss import FaissVectorIOAdapter
 
     assert isinstance(config, FaissVectorIOConfig), f"Unexpected config type: {type(config)}"
 
-    impl = FaissVectorIOAdapter(config, deps[Api.inference])
+    impl = FaissVectorIOAdapter(context, config, deps[Api.inference])
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/vector_io/faiss/faiss.py
+++ b/llama_stack/providers/inline/vector_io/faiss/faiss.py
@@ -19,7 +19,7 @@ from llama_stack.apis.common.content_types import InterleavedContent
 from llama_stack.apis.inference.inference import Inference
 from llama_stack.apis.vector_dbs import VectorDB
 from llama_stack.apis.vector_io import Chunk, QueryChunksResponse, VectorIO
-from llama_stack.providers.datatypes import VectorDBsProtocolPrivate
+from llama_stack.providers.datatypes import ProviderContext, VectorDBsProtocolPrivate
 from llama_stack.providers.utils.kvstore import kvstore_impl
 from llama_stack.providers.utils.kvstore.api import KVStore
 from llama_stack.providers.utils.memory.vector_store import (
@@ -114,9 +114,11 @@ class FaissIndex(EmbeddingIndex):
 
 
 class FaissVectorIOAdapter(VectorIO, VectorDBsProtocolPrivate):
-    def __init__(self, config: FaissVectorIOConfig, inference_api: Inference) -> None:
+    def __init__(self, context: ProviderContext, config: FaissVectorIOConfig, inference_api: Inference) -> None:
+        self.context = context
         self.config = config
         self.inference_api = inference_api
+        self.storage_dir = context.storage_dir if context else None
         self.cache: dict[str, VectorDBWithIndex] = {}
         self.kvstore: KVStore | None = None
 

--- a/llama_stack/providers/inline/vector_io/milvus/__init__.py
+++ b/llama_stack/providers/inline/vector_io/milvus/__init__.py
@@ -6,14 +6,15 @@
 
 from typing import Any
 
-from llama_stack.providers.datatypes import Api
+from llama_stack.providers.datatypes import Api, ProviderContext
 
 from .config import MilvusVectorIOConfig
 
 
-async def get_provider_impl(config: MilvusVectorIOConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: MilvusVectorIOConfig, deps: dict[Api, Any]):
     from llama_stack.providers.remote.vector_io.milvus.milvus import MilvusVectorIOAdapter
 
+    # Pass config directly since MilvusVectorIOAdapter doesn't accept context
     impl = MilvusVectorIOAdapter(config, deps[Api.inference])
     await impl.initialize()
     return impl

--- a/llama_stack/providers/inline/vector_io/sqlite_vec/__init__.py
+++ b/llama_stack/providers/inline/vector_io/sqlite_vec/__init__.py
@@ -6,15 +6,15 @@
 
 from typing import Any
 
-from llama_stack.providers.datatypes import Api
+from llama_stack.providers.datatypes import Api, ProviderContext
 
 from .config import SQLiteVectorIOConfig
 
 
-async def get_provider_impl(config: SQLiteVectorIOConfig, deps: dict[Api, Any]):
+async def get_provider_impl(context: ProviderContext, config: SQLiteVectorIOConfig, deps: dict[Api, Any]):
     from .sqlite_vec import SQLiteVecVectorIOAdapter
 
     assert isinstance(config, SQLiteVectorIOConfig), f"Unexpected config type: {type(config)}"
-    impl = SQLiteVecVectorIOAdapter(config, deps[Api.inference])
+    impl = SQLiteVecVectorIOAdapter(context, config, deps[Api.inference])
     await impl.initialize()
     return impl

--- a/llama_stack/providers/remote/inference/vllm/__init__.py
+++ b/llama_stack/providers/remote/inference/vllm/__init__.py
@@ -7,7 +7,7 @@
 from .config import VLLMInferenceAdapterConfig
 
 
-async def get_adapter_impl(config: VLLMInferenceAdapterConfig, _deps):
+async def get_adapter_impl(config: VLLMInferenceAdapterConfig, deps):
     from .vllm import VLLMInferenceAdapter
 
     assert isinstance(config, VLLMInferenceAdapterConfig), f"Unexpected config type: {type(config)}"

--- a/tests/unit/providers/agent/test_meta_reference_agent.py
+++ b/tests/unit/providers/agent/test_meta_reference_agent.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -20,6 +21,7 @@ from llama_stack.apis.inference import Inference
 from llama_stack.apis.safety import Safety
 from llama_stack.apis.tools import ToolGroups, ToolRuntime
 from llama_stack.apis.vector_io import VectorIO
+from llama_stack.providers.datatypes import ProviderContext
 from llama_stack.providers.inline.agents.meta_reference.agents import MetaReferenceAgentsImpl
 from llama_stack.providers.inline.agents.meta_reference.config import MetaReferenceAgentsImplConfig
 from llama_stack.providers.inline.agents.meta_reference.persistence import AgentInfo
@@ -48,7 +50,9 @@ def config(tmp_path):
 
 @pytest_asyncio.fixture
 async def agents_impl(config, mock_apis):
+    context = ProviderContext(storage_dir=Path("/tmp"))
     impl = MetaReferenceAgentsImpl(
+        context,
         config,
         mock_apis["inference_api"],
         mock_apis["vector_io_api"],

--- a/tests/unit/providers/inference/test_remote_vllm.py
+++ b/tests/unit/providers/inference/test_remote_vllm.py
@@ -62,9 +62,13 @@ class MockInferenceAdapterWithSleep:
             # ruff: noqa: N802
             def do_POST(self):
                 time.sleep(sleep_time)
+                response_json = json.dumps(response).encode("utf-8")
                 self.send_response(code=200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response_json)))
                 self.end_headers()
-                self.wfile.write(json.dumps(response).encode("utf-8"))
+                self.wfile.write(response_json)
+                self.wfile.flush()
 
         self.request_handler = DelayedRequestHandler
 

--- a/tests/unit/test_state_dir_resolution.py
+++ b/tests/unit/test_state_dir_resolution.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from pathlib import Path
+
+from llama_stack.distribution.resolver import resolve_storage_dir
+
+
+class DummyConfig:
+    pass
+
+
+def test_storage_dir_cli(monkeypatch):
+    config = DummyConfig()
+    config.storage_dir = "/cli/dir"
+    monkeypatch.delenv("LLAMA_STACK_STORAGE_DIR", raising=False)
+    result = resolve_storage_dir(config, "distro")
+    assert result == Path("/cli/dir")
+
+
+def test_storage_dir_env(monkeypatch):
+    config = DummyConfig()
+    if hasattr(config, "storage_dir"):
+        delattr(config, "storage_dir")
+    monkeypatch.setenv("LLAMA_STACK_STORAGE_DIR", "/env/dir")
+    result = resolve_storage_dir(config, "distro")
+    assert result == Path("/env/dir")
+
+
+def test_storage_dir_fallback(monkeypatch):
+    # Mock the DISTRIBS_BASE_DIR
+    monkeypatch.setattr("llama_stack.distribution.utils.config_dirs.DISTRIBS_BASE_DIR", Path("/mock/distribs"))
+
+    config = DummyConfig()
+    if hasattr(config, "storage_dir"):
+        delattr(config, "storage_dir")
+    monkeypatch.delenv("LLAMA_STACK_STORAGE_DIR", raising=False)
+
+    result = resolve_storage_dir(config, "distro")
+    assert result == Path("/mock/distribs/distro")


### PR DESCRIPTION
[_This PR implements #2139 but generalizes to separate runtime environments/contexts from specific provider configuration_]

This PR introduces a new `ProviderContext` object that decouples execution environment concerns from provider configuration. In this first iteration, the `ProviderContext` is used to introduce _storage directory_ which providers should use as base directory (e.g. for SQLite dbs). This allows removing absolute paths from templates and make the whole distribution more portable across environments. E.g. the current default to store everything in `~/.llama` might be difficult to use in a containerized environment where the notion of a $HOME directory might differ from base image to base image.

### Solution Details

   - Introduced a new `ProviderContext` class that encapsulates runtime environment information
   - Separates concerns between static configuration and runtime variables that depend on execution context
    - Updated provider interfaces to follow a consistent `context, config, deps` pattern
   - Provides consistent access to environment information across the codebase
   - Implemented a lookup for defining the storage directory:
     * CLI option (`--storage-dir`)
     * Environment variable (`LLAMA_STACK_STORAGE_DIR`)
     * Default distribution directory

> [!NOTE]
> - Only inline (local) providers have been updated in this PR
> - Remote adapters and other provider types are left out for the moment

## Next Steps
- Add ProviderContext objects to remote adapters (for now it is added only for local providers)
- Update templates to use relative pathes