### PR TITLE
(WIP) feat: associated models API with post_training

### DIFF
--- a/llama_stack/apis/datatypes.py
+++ b/llama_stack/apis/datatypes.py
@@ -27,6 +27,7 @@ class Api(Enum):
     telemetry = "telemetry"
 
     models = "models"
+    post_training_models = "post_training_models"
     shields = "shields"
     vector_dbs = "vector_dbs"
     datasets = "datasets"

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.common.job_types import JobStatus
 from llama_stack.apis.common.training_types import Checkpoint
+from llama_stack.apis.models import Model
 from llama_stack.schema_utils import json_schema_type, register_schema, webmethod
 
 
@@ -168,7 +169,13 @@ class PostTrainingJobArtifactsResponse(BaseModel):
     # TODO(ashwin): metrics, evals
 
 
+class ModelStore(Protocol):
+    async def get_model(self, identifier: str) -> Model: ...
+
+
 class PostTraining(Protocol):
+    model_store: ModelStore | None = None
+
     @webmethod(route="/post-training/supervised-fine-tune", method="POST")
     async def supervised_fine_tune(
         self,

--- a/llama_stack/distribution/distribution.py
+++ b/llama_stack/distribution/distribution.py
@@ -40,6 +40,10 @@ def builtin_automatically_routed_apis() -> list[AutoRoutedApiInfo]:
             router_api=Api.inference,
         ),
         AutoRoutedApiInfo(
+            routing_table_api=Api.post_training_models,
+            router_api=Api.post_training,
+        ),
+        AutoRoutedApiInfo(
             routing_table_api=Api.shields,
             router_api=Api.safety,
         ),

--- a/llama_stack/distribution/routers/post_training.py
+++ b/llama_stack/distribution/routers/post_training.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from typing import Any
+
+from llama_stack.apis.models import Model
+from llama_stack.apis.post_training import (
+    AlgorithmConfig,
+    DPOAlignmentConfig,
+    ListPostTrainingJobsResponse,
+    PostTraining,
+    PostTrainingJob,
+    PostTrainingJobArtifactsResponse,
+    PostTrainingJobStatusResponse,
+    TrainingConfig,
+)
+from llama_stack.log import get_logger
+from llama_stack.providers.datatypes import RoutingTable
+
+logger = get_logger(name=__name__, category="core")
+
+
+class PostTrainingRouter(PostTraining):
+    """Routes to an provider based on the model"""
+
+    async def initialize(self) -> None:
+        pass
+
+    def __init__(
+        self,
+        routing_table: RoutingTable,
+    ) -> None:
+        logger.debug("Initializing InferenceRouter")
+        self.routing_table = routing_table
+
+    async def supervised_fine_tune(
+        self,
+        job_uuid: str,
+        training_config: TrainingConfig,
+        hyperparam_search_config: dict[str, Any],
+        logger_config: dict[str, Any],
+        model: str,
+        checkpoint_dir: str | None = None,
+        algorithm_config: AlgorithmConfig | None = None,
+    ) -> PostTrainingJob:
+        provider = self.routing_table.get_provider_impl(model)
+        params = dict(
+            job_uuid=job_uuid,
+            training_config=training_config,
+            hyperparam_search_config=hyperparam_search_config,
+            logger_config=logger_config,
+            model=model,
+            checkpoint_dir=checkpoint_dir,
+            algorithm_config=algorithm_config,
+        )
+        return provider.supervised_fine_tune(**params)
+
+    async def register_model(self, model: Model) -> Model:
+        try:
+            # get static list of models
+            model = await self.register_helper.register_model(model)
+        except ValueError:
+            # if model is NOT in the list, its probably ok, but warn the user.
+            #
+            logger.warning(
+                f"Model {model.identifier} is not in the model registry for this provider, there might be unexpected issues."
+            )
+        if model.provider_resource_id is None:
+            raise ValueError("Model provider_resource_id cannot be None")
+        provider_resource_id = self.register_helper.get_provider_model_id(model.provider_resource_id)
+        if provider_resource_id is None:
+            provider_resource_id = model.provider_resource_id
+        model.provider_resource_id = provider_resource_id
+
+        return model
+
+    async def preference_optimize(
+        self,
+        job_uuid: str,
+        finetuned_model: str,
+        algorithm_config: DPOAlignmentConfig,
+        training_config: TrainingConfig,
+        hyperparam_search_config: dict[str, Any],
+        logger_config: dict[str, Any],
+    ) -> PostTrainingJob:
+        pass
+
+    async def get_training_jobs(self) -> ListPostTrainingJobsResponse:
+        pass
+
+    async def get_training_job_status(self, job_uuid: str) -> PostTrainingJobStatusResponse | None:
+        pass
+
+    async def cancel_training_job(self, job_uuid: str) -> None:
+        pass
+
+    async def get_training_job_artifacts(self, job_uuid: str) -> PostTrainingJobArtifactsResponse | None:
+        pass

--- a/llama_stack/providers/inline/post_training/huggingface/models.py
+++ b/llama_stack/providers/inline/post_training/huggingface/models.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from llama_stack.apis.models.models import ModelType
+from llama_stack.providers.utils.inference.model_registry import (
+    ProviderModelEntry,
+)
+
+model_entries = [
+    ProviderModelEntry(
+        provider_model_id="ibm-granite/granite-3.3-8b-instruct",
+        aliases=["ibm-granite/granite-3.3-8b-instruct"],
+        model_type=ModelType.llm,
+    ),
+    ProviderModelEntry(
+        provider_model_id="ibm-granite/granite-3.3-8b-instruct",
+        aliases=["ibm-granite/granite-3.3-8b-instruct"],
+        model_type=ModelType.llm,
+    ),
+]


### PR DESCRIPTION
# What does this PR do?

there are likely scenarios where admins of a stack only want to allow clients to fine-tune certain models, register certain models to be fine-tuned, etc. Introduce the post_training router and post_training_models as the associated type. A different model type needs to be used for inference vs post_training due to the structure of the router currently.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
`llama-stack-client models register <MODEL_ID> --provider-id huggingface`
`llama-stack-client models list`
<img width="1507" alt="Screenshot 2025-05-30 at 12 37 00 PM" src="https://github.com/user-attachments/assets/09cd664e-8c22-4114-8e49-4527cd8e70c5" />
