### PR TITLE
docs: Added a sample config for MCP provider documentation

### DIFF
--- a/llama_stack/providers/remote/tool_runtime/model_context_protocol/config.py
+++ b/llama_stack/providers/remote/tool_runtime/model_context_protocol/config.py
@@ -17,4 +17,10 @@ class MCPProviderDataValidator(BaseModel):
 class MCPProviderConfig(BaseModel):
     @classmethod
     def sample_run_config(cls, __distro_dir__: str, **kwargs: Any) -> dict[str, Any]:
-        return {}
+        return {
+            "provider_id" : "model-context-protocol", 
+            "toolgroup_id" : "mcp::samplemcp", 
+            "mcp_endpoint" : { 
+                "uri" : "http://localhost:7766/sse"
+            }
+        }


### PR DESCRIPTION
Added sample configuration for MCP

# What does this PR do?
Provided a sample configuration in the documentation for the tool runtime provider `remote::model-context-protocol`
