### PR TITLE
chore: add issue template for docs updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,28 @@
+name: 📚 Documentation Update
+description: Suggest a fix or addition to the Llama Stack documentation
+labels: ["documentation"]
+body:
+- type: textarea
+  id: doc-update-explanation
+  attributes:
+    label: 🤔 What is the documentation fix or addition you think should be addressed?
+    description: >
+      A clear and concise description of _what_ needs to be addressed.
+  validations:
+    required: true
+
+- type: textarea
+  id: doc-update-motivation
+  attributes:
+    label: 💡 What is the benefit of adding this to the documentation?
+    description: >
+      A clear and concise description of _why_ this work is needed.
+  validations:
+    required: true
+
+- type: textarea
+  id: other-thoughts
+  attributes:
+    label: Other thoughts
+    description: >
+      Any other related thoughts you may have.


### PR DESCRIPTION
# What does this PR do?
to further refine our issue backlog, create a template for maintainers/contributors/users to open issues
related to our documentation