### PR TITLE
Make provider_id Mandatory in Vector DB Registration to Avoid Ambiguity

### DIFF
--- a/llama_stack/apis/vector_dbs/vector_dbs.py
+++ b/llama_stack/apis/vector_dbs/vector_dbs.py
@@ -90,8 +90,8 @@ class VectorDBs(Protocol):
         self,
         vector_db_id: str,
         embedding_model: str,
+        provider_id: str,
         embedding_dimension: int | None = 384,
-        provider_id: str | None = None,
         vector_db_name: str | None = None,
         provider_vector_db_id: str | None = None,
     ) -> VectorDB:

--- a/llama_stack/core/routing_tables/vector_dbs.py
+++ b/llama_stack/core/routing_tables/vector_dbs.py
@@ -47,21 +47,12 @@ class VectorDBsRoutingTable(CommonRoutingTableImpl, VectorDBs):
         self,
         vector_db_id: str,
         embedding_model: str,
+        provider_id: str,
         embedding_dimension: int | None = 384,
-        provider_id: str | None = None,
         provider_vector_db_id: str | None = None,
         vector_db_name: str | None = None,
     ) -> VectorDB:
         provider_vector_db_id = provider_vector_db_id or vector_db_id
-        if provider_id is None:
-            if len(self.impls_by_provider_id) > 0:
-                provider_id = list(self.impls_by_provider_id.keys())[0]
-                if len(self.impls_by_provider_id) > 1:
-                    logger.warning(
-                        f"No provider specified and multiple providers available. Arbitrarily selected the first provider {provider_id}."
-                    )
-            else:
-                raise ValueError("No provider available. Please configure a vector_io provider.")
         model = await lookup_model(self, embedding_model)
         if model is None:
             raise ModelNotFoundError(embedding_model)


### PR DESCRIPTION


# What does this PR do?
This PR improves vector database registration by making provider_id a mandatory field, aligning with best practices across the codebase and ensuring consistent, explicit behavior.

Previously, if multiple vector_io providers were registered and no provider_id was provided, the system would arbitrarily pick the first provider or raise a less-clear error. This change eliminates ambiguity and ensures users always specify which provider to use.

Closes #2834 

## Test Plan
- Modified the register_vector_db method signature to require provider_id explicitly.
- Verified that API now returns a validation error when provider_id is missing.
- Confirmed behavior with multiple and single provider setups to ensure proper enforcement.

<img width="647" height="682" alt="Screenshot 2025-08-14 at 17 07 42" src="https://github.com/user-attachments/assets/c91195be-28d1-4497-9ac4-4774512958e2" />
<img width="644" height="672" alt="Screenshot 2025-08-14 at 17 08 35" src="https://github.com/user-attachments/assets/5c00fe06-27f7-4c2f-a187-89d6843c7ca3" />

