### PR TITLE
docs: fix post_training docs

### DIFF
--- a/docs/source/advanced_apis/post_training/inline_huggingface.md
+++ b/docs/source/advanced_apis/post_training/inline_huggingface.md
@@ -35,3 +35,6 @@ device: cpu
 
 ```
 
+[Find more detailed information here!](huggingface.md)
+
+

--- a/docs/source/advanced_apis/post_training/inline_torchtune.md
+++ b/docs/source/advanced_apis/post_training/inline_torchtune.md
@@ -22,3 +22,4 @@ checkpoint_format: meta
 
 ```
 
+[Find more detailed information here!](torchtune.md)


### PR DESCRIPTION
# What does this PR do?

the post training docs are missing references to the more indepth `huggingface.md` and `torchtune.md` which explain how to actually use the providers.

These files show up in search though.

Add references to these files into the `inline_..md` files currently pointed to by `index.md`

