### PR TITLE
chore(api): make version prefix optional

### DIFF
--- a/llama_stack/core/server/routes.py
+++ b/llama_stack/core/server/routes.py
@@ -60,7 +60,9 @@ def get_all_api_routes(
             # The __webmethod__ attribute is dynamically added by the @webmethod decorator
             # mypy doesn't know about this dynamic attribute, so we ignore the attr-defined error
             webmethod = method.__webmethod__  # type: ignore[attr-defined]
-            path = f"/{LLAMA_STACK_API_VERSION}/{webmethod.route.lstrip('/')}"
+            path = webmethod.route.lstrip("/")
+            if webmethod.add_version:
+                path = f"/{LLAMA_STACK_API_VERSION}/{path}"
             if webmethod.method == hdrs.METH_GET:
                 http_method = hdrs.METH_GET
             elif webmethod.method == hdrs.METH_DELETE:

--- a/llama_stack/schema_utils.py
+++ b/llama_stack/schema_utils.py
@@ -23,6 +23,7 @@ class WebMethod:
     descriptive_name: str | None = None
     experimental: bool | None = False
     required_scope: str | None = None
+    add_version: bool = True
 
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -38,6 +39,7 @@ def webmethod(
     descriptive_name: str | None = None,
     experimental: bool | None = False,
     required_scope: str | None = None,
+    add_version: bool = True,
 ) -> Callable[[T], T]:
     """
     Decorator that supplies additional metadata to an endpoint operation function.
@@ -61,6 +63,7 @@ def webmethod(
             descriptive_name=descriptive_name,
             experimental=experimental,
             required_scope=required_scope,
+            add_version=add_version,
         )
         return func
 


### PR DESCRIPTION
# What does this PR do?

it provides infrastructure for `@webmethod` endpoints that do not have / should not have a version prefix added, e.g. future openai endpoints.


## Test Plan

ci