### PR TITLE
fix(tests): set inference mode to be replay by default

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,6 +30,8 @@ def pytest_runtest_makereport(item, call):
 def pytest_sessionstart(session):
     # stop macOS from complaining about duplicate OpenMP libraries
     os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+    if "LLAMA_STACK_TEST_INFERENCE_MODE" not in os.environ:
+        os.environ["LLAMA_STACK_TEST_INFERENCE_MODE"] = "replay"
 
 
 def pytest_runtest_teardown(item):


### PR DESCRIPTION
`construct_stack()` relies on the environment variable to know when to setup the patching infrastructure
