### PR TITLE
feat: auto-detect Console width

### DIFF
--- a/.github/workflows/integration-auth-tests.yml
+++ b/.github/workflows/integration-auth-tests.yml
@@ -84,6 +84,8 @@ jobs:
           yq eval '.server.auth.provider_config.jwks.token = "${{ env.TOKEN }}"' -i $run_dir/run.yaml
           cat $run_dir/run.yaml
 
+          # avoid line breaks in the server log, especially because we grep it below.
+          export COLUMNS=1984
           nohup uv run llama stack run $run_dir/run.yaml --image-type venv > server.log 2>&1 &
 
       - name: Wait for Llama Stack server to be ready

--- a/llama_stack/log.py
+++ b/llama_stack/log.py
@@ -121,7 +121,7 @@ def strip_rich_markup(text):
 
 class CustomRichHandler(RichHandler):
     def __init__(self, *args, **kwargs):
-        kwargs["console"] = Console(width=150)
+        kwargs["console"] = Console()
         super().__init__(*args, **kwargs)
 
     def emit(self, record):


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Addresses Issue #3271 - "Starting LLS server locally on a terminal with 120 chars width results in an output with empty lines".

This removes the specific 150-character width limit specified for the Console, and will now auto-detect the terminal width instead. Now the formatting of Console output is consistent across different sizes of terminal windows.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes #3271

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
Launching the server with several different sizes of terminal windows results in Console output without unexpected spacing. e.g. `python -m llama_stack.core.server.server /tmp/run.yaml --port 8321`