### PR TITLE
chore(groq test): skip with_n tests for groq, it is not supported server-side

### DIFF
--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -63,6 +63,9 @@ def skip_if_doesnt_support_n(client_with_models, model_id):
     if provider.provider_type in (
         "remote::sambanova",
         "remote::ollama",
+        # https://console.groq.com/docs/openai#currently-unsupported-openai-features
+        # -> Error code: 400 - {'error': {'message': "'n' : number must be at most 1", 'type': 'invalid_request_error'}}
+        "remote::groq",
     ):
         pytest.skip(f"Model {model_id} hosted by {provider.provider_type} doesn't support n param.")
 


### PR DESCRIPTION
# What does this PR do?

skip the with_n test for groq, because it isn't supported by the provider's service

see https://console.groq.com/docs/openai#currently-unsupported-openai-features