### PR TITLE
fix: Add missing files_api parameter to MemoryToolRuntimeImpl test

### DIFF
--- a/tests/unit/rag/test_rag_query.py
+++ b/tests/unit/rag/test_rag_query.py
@@ -88,6 +88,7 @@ class TestRagQuery:
             config=MagicMock(),
             vector_io_api=MagicMock(),
             inference_api=MagicMock(),
+            files_api=MagicMock(),
         )
 
         vector_db_ids = ["db1", "db2"]


### PR DESCRIPTION

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
The test_query_adds_vector_db_id_to_chunk_metadata test was failing because MemoryToolRuntimeImpl.__init__() now requires a files_api parameter.

Fixes failing unit tests for Python 3.12 and 3.13.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
