### PR TITLE
fix: fireworks provider chat completion failing

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -6304,6 +6304,9 @@
                             "$ref": "#/components/schemas/TokenLogProbs"
                         },
                         "description": "Optional log probabilities for generated tokens"
+                    },
+                    "usage": {
+                        "$ref": "#/components/schemas/UsageInfo"
                     }
                 },
                 "additionalProperties": false,
@@ -6361,6 +6364,31 @@
                 ],
                 "title": "TokenLogProbs",
                 "description": "Log probabilities for generated tokens."
+            },
+            "UsageInfo": {
+                "type": "object",
+                "properties": {
+                    "completion_tokens": {
+                        "type": "integer",
+                        "description": "Number of tokens generated"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer",
+                        "description": "Number of tokens in the prompt"
+                    },
+                    "total_tokens": {
+                        "type": "integer",
+                        "description": "Total number of tokens processed"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "completion_tokens",
+                    "prompt_tokens",
+                    "total_tokens"
+                ],
+                "title": "UsageInfo",
+                "description": "Usage information for a model."
             },
             "BatchCompletionRequest": {
                 "type": "object",
@@ -10871,6 +10899,31 @@
                 "title": "OpenAIChatCompletionToolCallFunction",
                 "description": "Function call details for OpenAI-compatible tool calls."
             },
+            "OpenAIChatCompletionUsage": {
+                "type": "object",
+                "properties": {
+                    "prompt_tokens": {
+                        "type": "integer",
+                        "description": "The number of tokens in the prompt"
+                    },
+                    "completion_tokens": {
+                        "type": "integer",
+                        "description": "The number of tokens in the completion"
+                    },
+                    "total_tokens": {
+                        "type": "integer",
+                        "description": "The total number of tokens used"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "prompt_tokens",
+                    "completion_tokens",
+                    "total_tokens"
+                ],
+                "title": "OpenAIChatCompletionUsage",
+                "description": "Usage information for an OpenAI-compatible chat completion response."
+            },
             "OpenAIChoice": {
                 "type": "object",
                 "properties": {
@@ -11208,6 +11261,13 @@
             "OpenAICompletionWithInputMessages": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricInResponse"
+                        },
+                        "description": "(Optional) List of metrics associated with the API response"
+                    },
                     "id": {
                         "type": "string",
                         "description": "The ID of the chat completion"
@@ -11232,6 +11292,9 @@
                     "model": {
                         "type": "string",
                         "description": "The model that was used to generate the chat completion"
+                    },
+                    "usage": {
+                        "$ref": "#/components/schemas/OpenAIChatCompletionUsage"
                     },
                     "input_messages": {
                         "type": "array",
@@ -12994,6 +13057,13 @@
                         "items": {
                             "type": "object",
                             "properties": {
+                                "metrics": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MetricInResponse"
+                                    },
+                                    "description": "(Optional) List of metrics associated with the API response"
+                                },
                                 "id": {
                                     "type": "string",
                                     "description": "The ID of the chat completion"
@@ -13018,6 +13088,9 @@
                                 "model": {
                                     "type": "string",
                                     "description": "The model that was used to generate the chat completion"
+                                },
+                                "usage": {
+                                    "$ref": "#/components/schemas/OpenAIChatCompletionUsage"
                                 },
                                 "input_messages": {
                                     "type": "array",
@@ -14410,6 +14483,13 @@
             "OpenAIChatCompletion": {
                 "type": "object",
                 "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MetricInResponse"
+                        },
+                        "description": "(Optional) List of metrics associated with the API response"
+                    },
                     "id": {
                         "type": "string",
                         "description": "The ID of the chat completion"
@@ -14434,6 +14514,9 @@
                     "model": {
                         "type": "string",
                         "description": "The model that was used to generate the chat completion"
+                    },
+                    "usage": {
+                        "$ref": "#/components/schemas/OpenAIChatCompletionUsage"
                     }
                 },
                 "additionalProperties": false,

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -4499,6 +4499,8 @@ components:
             $ref: '#/components/schemas/TokenLogProbs'
           description: >-
             Optional log probabilities for generated tokens
+        usage:
+          $ref: '#/components/schemas/UsageInfo'
       additionalProperties: false
       required:
         - completion_message
@@ -4540,6 +4542,25 @@ components:
         - logprobs_by_token
       title: TokenLogProbs
       description: Log probabilities for generated tokens.
+    UsageInfo:
+      type: object
+      properties:
+        completion_tokens:
+          type: integer
+          description: Number of tokens generated
+        prompt_tokens:
+          type: integer
+          description: Number of tokens in the prompt
+        total_tokens:
+          type: integer
+          description: Total number of tokens processed
+      additionalProperties: false
+      required:
+        - completion_tokens
+        - prompt_tokens
+        - total_tokens
+      title: UsageInfo
+      description: Usage information for a model.
     BatchCompletionRequest:
       type: object
       properties:
@@ -8054,6 +8075,26 @@ components:
       title: OpenAIChatCompletionToolCallFunction
       description: >-
         Function call details for OpenAI-compatible tool calls.
+    OpenAIChatCompletionUsage:
+      type: object
+      properties:
+        prompt_tokens:
+          type: integer
+          description: The number of tokens in the prompt
+        completion_tokens:
+          type: integer
+          description: The number of tokens in the completion
+        total_tokens:
+          type: integer
+          description: The total number of tokens used
+      additionalProperties: false
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+      title: OpenAIChatCompletionUsage
+      description: >-
+        Usage information for an OpenAI-compatible chat completion response.
     OpenAIChoice:
       type: object
       properties:
@@ -8316,6 +8357,12 @@ components:
     OpenAICompletionWithInputMessages:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricInResponse'
+          description: >-
+            (Optional) List of metrics associated with the API response
         id:
           type: string
           description: The ID of the chat completion
@@ -8338,6 +8385,8 @@ components:
           type: string
           description: >-
             The model that was used to generate the chat completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
         input_messages:
           type: array
           items:
@@ -9633,6 +9682,12 @@ components:
           items:
             type: object
             properties:
+              metrics:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetricInResponse'
+                description: >-
+                  (Optional) List of metrics associated with the API response
               id:
                 type: string
                 description: The ID of the chat completion
@@ -9655,6 +9710,8 @@ components:
                 type: string
                 description: >-
                   The model that was used to generate the chat completion
+              usage:
+                $ref: '#/components/schemas/OpenAIChatCompletionUsage'
               input_messages:
                 type: array
                 items:
@@ -10670,6 +10727,12 @@ components:
     OpenAIChatCompletion:
       type: object
       properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricInResponse'
+          description: >-
+            (Optional) List of metrics associated with the API response
         id:
           type: string
           description: The ID of the chat completion
@@ -10692,6 +10755,8 @@ components:
           type: string
           description: >-
             The model that was used to generate the chat completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
       additionalProperties: false
       required:
         - id

--- a/llama_stack/apis/inference/inference.py
+++ b/llama_stack/apis/inference/inference.py
@@ -452,6 +452,20 @@ class ChatCompletionResponseStreamChunk(MetricResponseMixin):
 
 
 @json_schema_type
+class UsageInfo(BaseModel):
+    """Usage information for a model.
+
+    :param completion_tokens: Number of tokens generated
+    :param prompt_tokens: Number of tokens in the prompt
+    :param total_tokens: Total number of tokens processed
+    """
+
+    completion_tokens: int
+    prompt_tokens: int
+    total_tokens: int
+
+
+@json_schema_type
 class ChatCompletionResponse(MetricResponseMixin):
     """Response from a chat completion request.
 
@@ -461,6 +475,7 @@ class ChatCompletionResponse(MetricResponseMixin):
 
     completion_message: CompletionMessage
     logprobs: list[TokenLogProbs] | None = None
+    usage: UsageInfo | None = None
 
 
 @json_schema_type
@@ -818,7 +833,21 @@ class OpenAIChoice(BaseModel):
 
 
 @json_schema_type
-class OpenAIChatCompletion(BaseModel):
+class OpenAIChatCompletionUsage(BaseModel):
+    """Usage information for an OpenAI-compatible chat completion response.
+
+    :param prompt_tokens: The number of tokens in the prompt
+    :param completion_tokens: The number of tokens in the completion
+    :param total_tokens: The total number of tokens used
+    """
+
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+@json_schema_type
+class OpenAIChatCompletion(MetricResponseMixin):
     """Response from an OpenAI-compatible chat completion request.
 
     :param id: The ID of the chat completion
@@ -833,6 +862,7 @@ class OpenAIChatCompletion(BaseModel):
     object: Literal["chat.completion"] = "chat.completion"
     created: int
     model: str
+    usage: OpenAIChatCompletionUsage | None = None
 
 
 @json_schema_type

--- a/llama_stack/providers/utils/inference/openai_compat.py
+++ b/llama_stack/providers/utils/inference/openai_compat.py
@@ -1417,10 +1417,9 @@ class OpenAIChatCompletionToLlamaStackMixin:
         if stream:
             return OpenAIChatCompletionToLlamaStackMixin._process_stream_response(self, model, outstanding_responses)
 
-        response = await OpenAIChatCompletionToLlamaStackMixin._process_non_stream_response(
+        return await OpenAIChatCompletionToLlamaStackMixin._process_non_stream_response(
             self, model, outstanding_responses
         )
-        return response
 
     async def _process_stream_response(
         self,
@@ -1512,11 +1511,9 @@ class OpenAIChatCompletionToLlamaStackMixin:
             )
             choices.append(choice)
 
-        usage = None
-        if total_tokens > 0:
-            usage = OpenAIChatCompletionUsage(
-                prompt_tokens=total_prompt_tokens, completion_tokens=total_completion_tokens, total_tokens=total_tokens
-            )
+        usage = OpenAIChatCompletionUsage(
+            prompt_tokens=total_prompt_tokens, completion_tokens=total_completion_tokens, total_tokens=total_tokens
+        )
 
         return OpenAIChatCompletion(
             id=f"chatcmpl-{uuid.uuid4()}",


### PR DESCRIPTION
# What does this PR do?
Tried to fix earlier, however since fireworks api returns usage in response, this propagation can fix the end to end response to have the usage
Context in https://github.com/llamastack/llama-stack/pull/3392
Closes https://github.com/llamastack/llama-stack/issues/3391


## Test Plan
Build-run server then test with curl
```
(llama-stack) (base) swapna942@swapna942-mac llama-stack % curl -X POST http://localhost:8321/v1/openai/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "X-LlamaStack-Provider-Data: {\"fireworks_api_key\": \"$FIREWORKS_API_KEY\"}" \
      -d '{
        "model": "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct",
        "messages": [{"role": "user", "content": "Hello!"}]
      }' | jq
{
  "metrics": [
    {
      "metric": "prompt_tokens",
      "value": 35,
      "unit": "tokens"
    },
    {
      "metric": "completion_tokens",
      "value": 10,
      "unit": "tokens"
    },
    {
      "metric": "total_tokens",
      "value": 45,
      "unit": "tokens"
    }
  ],
  "id": "chatcmpl-0646bc72-cf4a-4afd-8fa0-030275b452f6",
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "Hello! How can I assist you today?",
        "name": null,
        "tool_calls": null
      },
      "finish_reason": "stop",
      "index": 0,
      "logprobs": null
    }
  ],
  "object": "chat.completion",
  "created": 1757632496,
  "model": "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct",
  "usage": {
    "prompt_tokens": 35,
    "completion_tokens": 10,
    "total_tokens": 45
  }
} 
```