### PR TITLE
chore(tests): always show slowest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,7 @@ warn_required_dynamic_aliases = true
 classmethod-decorators = ["classmethod", "pydantic.field_validator"]
 
 [tool.pytest.ini_options]
+addopts = ["--durations=10"]
 asyncio_mode = "auto"
 markers = [
     "allow_network: Allow network access for specific unit tests",


### PR DESCRIPTION
# What does this PR do?

help developers identify slow tests by always passing --duration to pytest


## Test Plan

n/a