### PR TITLE
docs: Fix incorrect vector_db_id usage in RAG tutorial

### DIFF
--- a/docs/source/getting_started/detailed_tutorial.md
+++ b/docs/source/getting_started/detailed_tutorial.md
@@ -460,10 +460,12 @@ client = LlamaStackClient(base_url="http://localhost:8321")
 embed_lm = next(m for m in client.models.list() if m.model_type == "embedding")
 embedding_model = embed_lm.identifier
 vector_db_id = f"v{uuid.uuid4().hex}"
-client.vector_dbs.register(
+# The VectorDB API is deprecated; the server now returns its own authoritative ID.
+# We capture the correct ID from the response's .identifier attribute.
+vector_db_id = client.vector_dbs.register(
     vector_db_id=vector_db_id,
     embedding_model=embedding_model,
-)
+).identifier
 
 # Create Documents
 urls = [


### PR DESCRIPTION
# What does this PR do?
This PR fixes a blocking issue in the detailed RAG tutorial where the code fails with a 400 Bad Request error.

The root cause is that recent versions of Llama-Stack ignore the client-generated vector_db_id and assign a new server-side ID. The tutorial was not updated to reflect this, causing the rag_tool.insert call to fail.

This change updates the code to capture the authoritative ID from the .identifier attribute of the register() method's response. This ensures the tutorial code runs successfully and reflects the current API behavior.

## Test Plan
The fix can be verified by running the Python code snippet from the detailed tutorial page.

Run the original code (Before this change):

Result: The script fails with a 400 Bad Request error on the rag_tool.insert step.

Run the updated code (After this change):

Result: The script runs successfully to completion.
