### PR TITLE
fix:  change ModelRegistryHelper to use ProviderModelEntry instead of hardcoded ModelType.llm 

### DIFF
--- a/llama_stack/providers/utils/inference/model_registry.py
+++ b/llama_stack/providers/utils/inference/model_registry.py
@@ -103,7 +103,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
                     Model(
                         identifier=id,
                         provider_resource_id=entry.provider_model_id,
-                        model_type=ModelType.llm,
+                        model_type=entry.model_type,
                         metadata=entry.metadata,
                         provider_id=self.__provider_id__,
                     )


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
change ModelRegistryHelper to use ProviderModelEntry instead of hardcoded ModelType.llm  which fixed issue #3330.
<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[3330] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
1. open llama-stack server 
```
uv sync --python 3.12
source .venv/bin/activate
uv run llama stack build --distro starter --image-type venv  --run
```
2.Used following script to test 
```
from llama_stack_client import LlamaStackClient
import os
def test_openai_embedding_type():
    client = LlamaStackClient(
        base_url=os.environ.get("LLAMA_STACK_ENDPOINT", "http://localhost:8321"),
        provider_data={
        "openai_api_key": os.environ.get("OPENAI_API_KEY", ""),
    },
    )
    model = client.models.retrieve("openai/text-embedding-3-small")
    print(model)
    assert model.identifier == "openai/text-embedding-3-small"
    assert model.model_type == "embedding"
test_openai_embedding_type()
```
logs:
```
python test_openai.py
INFO:httpx:HTTP Request: GET http://localhost:8321/v1/models/openai/text-embedding-3-small "HTTP/1.1 200 OK"
Model(identifier='openai/text-embedding-3-small', metadata={'embedding_dimension': 1536.0, 'context_length': 8192.0}, api_model_type='embedding', provider_id='openai', type='model', provider_resource_id='text-embedding-3-small', owner=None, source='listed_from_provider', model_type='embedding')
```