### PR TITLE
feat(api): implement v1beta leveling

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -172,7 +172,7 @@
                 }
             }
         },
-        "/v1/post-training/job/cancel": {
+        "/v1alpha/post-training/job/cancel": {
             "post": {
                 "responses": {
                     "200": {
@@ -2035,7 +2035,7 @@
                 ]
             }
         },
-        "/v1/post-training/job/artifacts": {
+        "/v1alpha/post-training/job/artifacts": {
             "get": {
                 "responses": {
                     "200": {
@@ -2078,7 +2078,7 @@
                 ]
             }
         },
-        "/v1/post-training/job/status": {
+        "/v1alpha/post-training/job/status": {
             "get": {
                 "responses": {
                     "200": {
@@ -2121,7 +2121,7 @@
                 ]
             }
         },
-        "/v1/post-training/jobs": {
+        "/v1alpha/post-training/jobs": {
             "get": {
                 "responses": {
                     "200": {
@@ -4681,7 +4681,7 @@
                 }
             }
         },
-        "/v1/post-training/preference-optimize": {
+        "/v1alpha/post-training/preference-optimize": {
             "post": {
                 "responses": {
                     "200": {
@@ -5382,7 +5382,7 @@
                 }
             }
         },
-        "/v1/post-training/supervised-fine-tune": {
+        "/v1alpha/post-training/supervised-fine-tune": {
             "post": {
                 "responses": {
                     "200": {

--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -40,7 +40,7 @@
         }
     ],
     "paths": {
-        "/v1/datasetio/append-rows/{dataset_id}": {
+        "/v1beta/datasetio/append-rows/{dataset_id}": {
             "post": {
                 "responses": {
                     "200": {
@@ -1155,7 +1155,7 @@
                 }
             }
         },
-        "/v1/eval/benchmarks/{benchmark_id}/evaluations": {
+        "/v1beta/eval/benchmarks/{benchmark_id}/evaluations": {
             "post": {
                 "responses": {
                     "200": {
@@ -1459,7 +1459,7 @@
                 ]
             }
         },
-        "/v1/datasets/{dataset_id}": {
+        "/v1beta/datasets/{dataset_id}": {
             "get": {
                 "responses": {
                     "200": {
@@ -1767,7 +1767,7 @@
                 ]
             }
         },
-        "/v1/telemetry/traces/{trace_id}/spans/{span_id}": {
+        "/v1beta/telemetry/traces/{trace_id}/spans/{span_id}": {
             "get": {
                 "responses": {
                     "200": {
@@ -1819,7 +1819,7 @@
                 ]
             }
         },
-        "/v1/telemetry/spans/{span_id}/tree": {
+        "/v1beta/telemetry/spans/{span_id}/tree": {
             "post": {
                 "responses": {
                     "200": {
@@ -1992,7 +1992,7 @@
                 ]
             }
         },
-        "/v1/telemetry/traces/{trace_id}": {
+        "/v1beta/telemetry/traces/{trace_id}": {
             "get": {
                 "responses": {
                     "200": {
@@ -2422,7 +2422,7 @@
                 }
             }
         },
-        "/v1/datasetio/iterrows/{dataset_id}": {
+        "/v1beta/datasetio/iterrows/{dataset_id}": {
             "get": {
                 "responses": {
                     "200": {
@@ -2483,7 +2483,7 @@
                 ]
             }
         },
-        "/v1/eval/benchmarks/{benchmark_id}/jobs/{job_id}": {
+        "/v1beta/eval/benchmarks/{benchmark_id}/jobs/{job_id}": {
             "get": {
                 "responses": {
                     "200": {
@@ -2578,7 +2578,7 @@
                 ]
             }
         },
-        "/v1/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result": {
+        "/v1beta/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result": {
             "get": {
                 "responses": {
                     "200": {
@@ -2876,7 +2876,7 @@
                 }
             }
         },
-        "/v1/datasets": {
+        "/v1beta/datasets": {
             "get": {
                 "responses": {
                     "200": {
@@ -3601,7 +3601,7 @@
                 }
             }
         },
-        "/v1/telemetry/events": {
+        "/v1beta/telemetry/events": {
             "post": {
                 "responses": {
                     "200": {
@@ -4810,7 +4810,7 @@
                 }
             }
         },
-        "/v1/telemetry/metrics/{metric_name}": {
+        "/v1beta/telemetry/metrics/{metric_name}": {
             "post": {
                 "responses": {
                     "200": {
@@ -4863,7 +4863,7 @@
                 }
             }
         },
-        "/v1/telemetry/spans": {
+        "/v1beta/telemetry/spans": {
             "post": {
                 "responses": {
                     "200": {
@@ -4906,7 +4906,7 @@
                 }
             }
         },
-        "/v1/telemetry/traces": {
+        "/v1beta/telemetry/traces": {
             "post": {
                 "responses": {
                     "200": {
@@ -5068,7 +5068,7 @@
                 }
             }
         },
-        "/v1/eval/benchmarks/{benchmark_id}/jobs": {
+        "/v1beta/eval/benchmarks/{benchmark_id}/jobs": {
             "post": {
                 "responses": {
                     "200": {
@@ -5207,7 +5207,7 @@
                 }
             }
         },
-        "/v1/telemetry/spans/export": {
+        "/v1beta/telemetry/spans/export": {
             "post": {
                 "responses": {
                     "200": {

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -104,7 +104,7 @@ paths:
             schema:
               $ref: '#/components/schemas/BatchCompletionRequest'
         required: true
-  /v1/post-training/job/cancel:
+  /v1alpha/post-training/job/cancel:
     post:
       responses:
         '200':
@@ -1404,7 +1404,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/post-training/job/artifacts:
+  /v1alpha/post-training/job/artifacts:
     get:
       responses:
         '200':
@@ -1434,7 +1434,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/post-training/job/status:
+  /v1alpha/post-training/job/status:
     get:
       responses:
         '200':
@@ -1464,7 +1464,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/post-training/jobs:
+  /v1alpha/post-training/jobs:
     get:
       responses:
         '200':
@@ -3325,7 +3325,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenaiSearchVectorStoreRequest'
         required: true
-  /v1/post-training/preference-optimize:
+  /v1alpha/post-training/preference-optimize:
     post:
       responses:
         '200':
@@ -3812,7 +3812,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SetDefaultVersionRequest'
         required: true
-  /v1/post-training/supervised-fine-tune:
+  /v1alpha/post-training/supervised-fine-tune:
     post:
       responses:
         '200':

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -10,7 +10,7 @@ info:
 servers:
   - url: http://any-hosted-llama-stack.com
 paths:
-  /v1/datasetio/append-rows/{dataset_id}:
+  /v1beta/datasetio/append-rows/{dataset_id}:
     post:
       responses:
         '200':
@@ -798,7 +798,7 @@ paths:
             schema:
               $ref: '#/components/schemas/EmbeddingsRequest'
         required: true
-  /v1/eval/benchmarks/{benchmark_id}/evaluations:
+  /v1beta/eval/benchmarks/{benchmark_id}/evaluations:
     post:
       responses:
         '200':
@@ -1007,7 +1007,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/datasets/{dataset_id}:
+  /v1beta/datasets/{dataset_id}:
     get:
       responses:
         '200':
@@ -1222,7 +1222,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/telemetry/traces/{trace_id}/spans/{span_id}:
+  /v1beta/telemetry/traces/{trace_id}/spans/{span_id}:
     get:
       responses:
         '200':
@@ -1258,7 +1258,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/telemetry/spans/{span_id}/tree:
+  /v1beta/telemetry/spans/{span_id}/tree:
     post:
       responses:
         '200':
@@ -1375,7 +1375,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/telemetry/traces/{trace_id}:
+  /v1beta/telemetry/traces/{trace_id}:
     get:
       responses:
         '200':
@@ -1678,7 +1678,7 @@ paths:
             schema:
               $ref: '#/components/schemas/InvokeToolRequest'
         required: true
-  /v1/datasetio/iterrows/{dataset_id}:
+  /v1beta/datasetio/iterrows/{dataset_id}:
     get:
       responses:
         '200':
@@ -1735,7 +1735,7 @@ paths:
           required: false
           schema:
             type: integer
-  /v1/eval/benchmarks/{benchmark_id}/jobs/{job_id}:
+  /v1beta/eval/benchmarks/{benchmark_id}/jobs/{job_id}:
     get:
       responses:
         '200':
@@ -1802,7 +1802,7 @@ paths:
           required: true
           schema:
             type: string
-  /v1/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result:
+  /v1beta/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result:
     get:
       responses:
         '200':
@@ -2010,7 +2010,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenaiChatCompletionRequest'
         required: true
-  /v1/datasets:
+  /v1beta/datasets:
     get:
       responses:
         '200':
@@ -2524,7 +2524,7 @@ paths:
             schema:
               $ref: '#/components/schemas/RegisterVectorDbRequest'
         required: true
-  /v1/telemetry/events:
+  /v1beta/telemetry/events:
     post:
       responses:
         '200':
@@ -3414,7 +3414,7 @@ paths:
             schema:
               $ref: '#/components/schemas/QueryChunksRequest'
         required: true
-  /v1/telemetry/metrics/{metric_name}:
+  /v1beta/telemetry/metrics/{metric_name}:
     post:
       responses:
         '200':
@@ -3449,7 +3449,7 @@ paths:
             schema:
               $ref: '#/components/schemas/QueryMetricsRequest'
         required: true
-  /v1/telemetry/spans:
+  /v1beta/telemetry/spans:
     post:
       responses:
         '200':
@@ -3478,7 +3478,7 @@ paths:
             schema:
               $ref: '#/components/schemas/QuerySpansRequest'
         required: true
-  /v1/telemetry/traces:
+  /v1beta/telemetry/traces:
     post:
       responses:
         '200':
@@ -3595,7 +3595,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ResumeAgentTurnRequest'
         required: true
-  /v1/eval/benchmarks/{benchmark_id}/jobs:
+  /v1beta/eval/benchmarks/{benchmark_id}/jobs:
     post:
       responses:
         '200':
@@ -3691,7 +3691,7 @@ paths:
             schema:
               $ref: '#/components/schemas/RunShieldRequest'
         required: true
-  /v1/telemetry/spans/export:
+  /v1beta/telemetry/spans/export:
     post:
       responses:
         '200':

--- a/docs/openapi_generator/generate.py
+++ b/docs/openapi_generator/generate.py
@@ -16,7 +16,7 @@ import sys
 import fire
 import ruamel.yaml as yaml
 
-from llama_stack.apis.version import LLAMA_STACK_API_VERSION  # noqa: E402
+from llama_stack.apis.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1ALPHA, LLAMA_STACK_API_V1BETA  # noqa: E402
 from llama_stack.core.stack import LlamaStack  # noqa: E402
 
 from .pyopenapi.options import Options  # noqa: E402
@@ -25,7 +25,7 @@ from .pyopenapi.utility import Specification, validate_api  # noqa: E402
 
 
 def str_presenter(dumper, data):
-    if data.startswith(f"/{LLAMA_STACK_API_VERSION}") or data.startswith(
+    if data.startswith(f"/{LLAMA_STACK_API_V1}") or data.startswith(f"/{LLAMA_STACK_API_V1ALPHA}") or data.startswith(f"/{LLAMA_STACK_API_V1BETA}") or data.startswith(
         "#/components/schemas/"
     ):
         style = None
@@ -58,7 +58,7 @@ def main(output_dir: str):
             server=Server(url="http://any-hosted-llama-stack.com"),
             info=Info(
                 title="Llama Stack Specification",
-                version=LLAMA_STACK_API_VERSION,
+                version=LLAMA_STACK_API_V1,
                 description="""This is the specification of the Llama Stack that provides
                 a set of endpoints and their corresponding interfaces that are tailored to
                 best leverage Llama Models.""",

--- a/docs/openapi_generator/pyopenapi/operations.py
+++ b/docs/openapi_generator/pyopenapi/operations.py
@@ -11,7 +11,7 @@ import typing
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-from llama_stack.apis.version import LLAMA_STACK_API_VERSION
+from llama_stack.apis.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1BETA, LLAMA_STACK_API_V1ALPHA
 
 from termcolor import colored
 
@@ -114,10 +114,14 @@ class EndpointOperation:
     response_examples: Optional[List[Any]] = None
 
     def get_route(self) -> str:
+        # Get the API level from the webmethod decorator
+        webmethod = getattr(self.func_ref, "__webmethod__", None)
+        api_level = webmethod.level if webmethod and hasattr(webmethod, 'level') else LLAMA_STACK_API_V1
+        
         if self.route is not None:
-            return "/".join(["", LLAMA_STACK_API_VERSION, self.route.lstrip("/")])
+            return "/".join(["", api_level, self.route.lstrip("/")])
 
-        route_parts = ["", LLAMA_STACK_API_VERSION, self.name]
+        route_parts = ["", api_level, self.name]
         for param_name, _ in self.path_params:
             route_parts.append("{" + param_name + "}")
         return "/".join(route_parts)

--- a/llama_stack/apis/datasetio/datasetio.py
+++ b/llama_stack/apis/datasetio/datasetio.py
@@ -20,7 +20,7 @@ class DatasetIO(Protocol):
     # keeping for aligning with inference/safety, but this is not used
     dataset_store: DatasetStore
 
-    @webmethod(route="/datasetio/iterrows/{dataset_id:path}", method="GET")
+    @webmethod(route="/datasetio/iterrows/{dataset_id:path}", method="GET", level="v1beta")
     async def iterrows(
         self,
         dataset_id: str,
@@ -44,7 +44,7 @@ class DatasetIO(Protocol):
         """
         ...
 
-    @webmethod(route="/datasetio/append-rows/{dataset_id:path}", method="POST")
+    @webmethod(route="/datasetio/append-rows/{dataset_id:path}", method="POST", level="v1beta")
     async def append_rows(self, dataset_id: str, rows: list[dict[str, Any]]) -> None:
         """Append rows to a dataset.
 

--- a/llama_stack/apis/datasets/datasets.py
+++ b/llama_stack/apis/datasets/datasets.py
@@ -145,7 +145,7 @@ class ListDatasetsResponse(BaseModel):
 
 
 class Datasets(Protocol):
-    @webmethod(route="/datasets", method="POST")
+    @webmethod(route="/datasets", method="POST", level="v1beta")
     async def register_dataset(
         self,
         purpose: DatasetPurpose,
@@ -214,7 +214,7 @@ class Datasets(Protocol):
         """
         ...
 
-    @webmethod(route="/datasets/{dataset_id:path}", method="GET")
+    @webmethod(route="/datasets/{dataset_id:path}", method="GET", level="v1beta")
     async def get_dataset(
         self,
         dataset_id: str,
@@ -226,7 +226,7 @@ class Datasets(Protocol):
         """
         ...
 
-    @webmethod(route="/datasets", method="GET")
+    @webmethod(route="/datasets", method="GET", level="v1beta")
     async def list_datasets(self) -> ListDatasetsResponse:
         """List all datasets.
 
@@ -234,7 +234,7 @@ class Datasets(Protocol):
         """
         ...
 
-    @webmethod(route="/datasets/{dataset_id:path}", method="DELETE")
+    @webmethod(route="/datasets/{dataset_id:path}", method="DELETE", level="v1beta")
     async def unregister_dataset(
         self,
         dataset_id: str,

--- a/llama_stack/apis/eval/eval.py
+++ b/llama_stack/apis/eval/eval.py
@@ -83,7 +83,7 @@ class EvaluateResponse(BaseModel):
 class Eval(Protocol):
     """Llama Stack Evaluation API for running evaluations on model and agent candidates."""
 
-    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs", method="POST")
+    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs", method="POST", level="v1beta")
     async def run_eval(
         self,
         benchmark_id: str,
@@ -97,7 +97,7 @@ class Eval(Protocol):
         """
         ...
 
-    @webmethod(route="/eval/benchmarks/{benchmark_id}/evaluations", method="POST")
+    @webmethod(route="/eval/benchmarks/{benchmark_id}/evaluations", method="POST", level="v1beta")
     async def evaluate_rows(
         self,
         benchmark_id: str,
@@ -115,7 +115,7 @@ class Eval(Protocol):
         """
         ...
 
-    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs/{job_id}", method="GET")
+    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs/{job_id}", method="GET", level="v1beta")
     async def job_status(self, benchmark_id: str, job_id: str) -> Job:
         """Get the status of a job.
 
@@ -125,7 +125,7 @@ class Eval(Protocol):
         """
         ...
 
-    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs/{job_id}", method="DELETE")
+    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs/{job_id}", method="DELETE", level="v1beta")
     async def job_cancel(self, benchmark_id: str, job_id: str) -> None:
         """Cancel a job.
 
@@ -134,7 +134,7 @@ class Eval(Protocol):
         """
         ...
 
-    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result", method="GET")
+    @webmethod(route="/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result", method="GET", level="v1beta")
     async def job_result(self, benchmark_id: str, job_id: str) -> EvaluateResponse:
         """Get the result of a job.
 

--- a/llama_stack/apis/post_training/post_training.py
+++ b/llama_stack/apis/post_training/post_training.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from llama_stack.apis.common.content_types import URL
 from llama_stack.apis.common.job_types import JobStatus
 from llama_stack.apis.common.training_types import Checkpoint
+from llama_stack.apis.version import LLAMA_STACK_API_V1ALPHA
 from llama_stack.schema_utils import json_schema_type, register_schema, webmethod
 
 
@@ -283,7 +284,7 @@ class PostTrainingJobArtifactsResponse(BaseModel):
 
 
 class PostTraining(Protocol):
-    @webmethod(route="/post-training/supervised-fine-tune", method="POST")
+    @webmethod(route="/post-training/supervised-fine-tune", method="POST", level=LLAMA_STACK_API_V1ALPHA)
     async def supervised_fine_tune(
         self,
         job_uuid: str,
@@ -310,7 +311,7 @@ class PostTraining(Protocol):
         """
         ...
 
-    @webmethod(route="/post-training/preference-optimize", method="POST")
+    @webmethod(route="/post-training/preference-optimize", method="POST", level=LLAMA_STACK_API_V1ALPHA)
     async def preference_optimize(
         self,
         job_uuid: str,
@@ -332,7 +333,7 @@ class PostTraining(Protocol):
         """
         ...
 
-    @webmethod(route="/post-training/jobs", method="GET")
+    @webmethod(route="/post-training/jobs", method="GET", level=LLAMA_STACK_API_V1ALPHA)
     async def get_training_jobs(self) -> ListPostTrainingJobsResponse:
         """Get all training jobs.
 
@@ -340,7 +341,7 @@ class PostTraining(Protocol):
         """
         ...
 
-    @webmethod(route="/post-training/job/status", method="GET")
+    @webmethod(route="/post-training/job/status", method="GET", level=LLAMA_STACK_API_V1ALPHA)
     async def get_training_job_status(self, job_uuid: str) -> PostTrainingJobStatusResponse:
         """Get the status of a training job.
 
@@ -349,7 +350,7 @@ class PostTraining(Protocol):
         """
         ...
 
-    @webmethod(route="/post-training/job/cancel", method="POST")
+    @webmethod(route="/post-training/job/cancel", method="POST", level=LLAMA_STACK_API_V1ALPHA)
     async def cancel_training_job(self, job_uuid: str) -> None:
         """Cancel a training job.
 
@@ -357,7 +358,7 @@ class PostTraining(Protocol):
         """
         ...
 
-    @webmethod(route="/post-training/job/artifacts", method="GET")
+    @webmethod(route="/post-training/job/artifacts", method="GET", level=LLAMA_STACK_API_V1ALPHA)
     async def get_training_job_artifacts(self, job_uuid: str) -> PostTrainingJobArtifactsResponse:
         """Get the artifacts of a training job.
 

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -412,7 +412,7 @@ class QueryMetricsResponse(BaseModel):
 
 @runtime_checkable
 class Telemetry(Protocol):
-    @webmethod(route="/telemetry/events", method="POST")
+    @webmethod(route="/telemetry/events", method="POST", level="v1beta")
     async def log_event(
         self,
         event: Event,
@@ -425,7 +425,7 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/traces", method="POST", required_scope=REQUIRED_SCOPE)
+    @webmethod(route="/telemetry/traces", method="POST", required_scope=REQUIRED_SCOPE, level="v1beta")
     async def query_traces(
         self,
         attribute_filters: list[QueryCondition] | None = None,
@@ -443,7 +443,7 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/traces/{trace_id:path}", method="GET", required_scope=REQUIRED_SCOPE)
+    @webmethod(route="/telemetry/traces/{trace_id:path}", method="GET", required_scope=REQUIRED_SCOPE, level="v1beta")
     async def get_trace(self, trace_id: str) -> Trace:
         """Get a trace by its ID.
 
@@ -453,7 +453,10 @@ class Telemetry(Protocol):
         ...
 
     @webmethod(
-        route="/telemetry/traces/{trace_id:path}/spans/{span_id:path}", method="GET", required_scope=REQUIRED_SCOPE
+        route="/telemetry/traces/{trace_id:path}/spans/{span_id:path}",
+        method="GET",
+        required_scope=REQUIRED_SCOPE,
+        level="v1beta",
     )
     async def get_span(self, trace_id: str, span_id: str) -> Span:
         """Get a span by its ID.
@@ -464,7 +467,9 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/spans/{span_id:path}/tree", method="POST", required_scope=REQUIRED_SCOPE)
+    @webmethod(
+        route="/telemetry/spans/{span_id:path}/tree", method="POST", required_scope=REQUIRED_SCOPE, level="v1beta"
+    )
     async def get_span_tree(
         self,
         span_id: str,
@@ -480,7 +485,7 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/spans", method="POST", required_scope=REQUIRED_SCOPE)
+    @webmethod(route="/telemetry/spans", method="POST", required_scope=REQUIRED_SCOPE, level="v1beta")
     async def query_spans(
         self,
         attribute_filters: list[QueryCondition],
@@ -496,7 +501,7 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/spans/export", method="POST")
+    @webmethod(route="/telemetry/spans/export", method="POST", level="v1beta")
     async def save_spans_to_dataset(
         self,
         attribute_filters: list[QueryCondition],
@@ -513,7 +518,7 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/metrics/{metric_name}", method="POST", required_scope=REQUIRED_SCOPE)
+    @webmethod(route="/telemetry/metrics/{metric_name}", method="POST", required_scope=REQUIRED_SCOPE, level="v1beta")
     async def query_metrics(
         self,
         metric_name: str,

--- a/llama_stack/apis/version.py
+++ b/llama_stack/apis/version.py
@@ -4,4 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-LLAMA_STACK_API_VERSION = "v1"
+LLAMA_STACK_API_V1 = "v1"
+LLAMA_STACK_API_V1BETA = "v1beta"
+LLAMA_STACK_API_V1ALPHA = "v1alpha"

--- a/llama_stack/core/client.py
+++ b/llama_stack/core/client.py
@@ -15,7 +15,6 @@ import httpx
 from pydantic import BaseModel, parse_obj_as
 from termcolor import cprint
 
-from llama_stack.apis.version import LLAMA_STACK_API_VERSION
 from llama_stack.providers.datatypes import RemoteProviderConfig
 
 _CLIENT_CLASSES = {}
@@ -114,7 +113,7 @@ def create_api_client_class(protocol) -> type:
                     break
                 kwargs[param.name] = args[i]
 
-            url = f"{self.base_url}/{LLAMA_STACK_API_VERSION}/{webmethod.route.lstrip('/')}"
+            url = f"{self.base_url}/{webmethod.level}/{webmethod.route.lstrip('/')}"
 
             def convert(value):
                 if isinstance(value, list):

--- a/llama_stack/core/server/routes.py
+++ b/llama_stack/core/server/routes.py
@@ -14,7 +14,6 @@ from starlette.routing import Route
 
 from llama_stack.apis.datatypes import Api, ExternalApiSpec
 from llama_stack.apis.tools import RAGToolRuntime, SpecialToolGroup
-from llama_stack.apis.version import LLAMA_STACK_API_VERSION
 from llama_stack.core.resolver import api_protocol_map
 from llama_stack.schema_utils import WebMethod
 
@@ -60,7 +59,7 @@ def get_all_api_routes(
             # The __webmethod__ attribute is dynamically added by the @webmethod decorator
             # mypy doesn't know about this dynamic attribute, so we ignore the attr-defined error
             webmethod = method.__webmethod__  # type: ignore[attr-defined]
-            path = f"/{LLAMA_STACK_API_VERSION}/{webmethod.route.lstrip('/')}"
+            path = f"/{webmethod.level}/{webmethod.route.lstrip('/')}"
             if webmethod.method == hdrs.METH_GET:
                 http_method = hdrs.METH_GET
             elif webmethod.method == hdrs.METH_DELETE:

--- a/llama_stack/providers/remote/datasetio/nvidia/datasetio.py
+++ b/llama_stack/providers/remote/datasetio/nvidia/datasetio.py
@@ -78,7 +78,7 @@ class NvidiaDatasetIOAdapter:
             request_body["description"] = dataset_def.metadata.get("description")
         await self._make_request(
             "POST",
-            "/v1/datasets",
+            "/v1beta/datasets",
             json=request_body,
         )
         return dataset_def
@@ -100,7 +100,7 @@ class NvidiaDatasetIOAdapter:
     ) -> None:
         await self._make_request(
             "DELETE",
-            f"/v1/datasets/{self.config.dataset_namespace}/{dataset_id}",
+            f"/v1beta/datasets/{self.config.dataset_namespace}/{dataset_id}",
             headers={"Accept": "application/json", "Content-Type": "application/json"},
         )
 

--- a/llama_stack/schema_utils.py
+++ b/llama_stack/schema_utils.py
@@ -13,6 +13,7 @@ from .strong_typing.schema import json_schema_type, register_schema  # noqa: F40
 
 @dataclass
 class WebMethod:
+    level: str | None = "v1"
     route: str | None = None
     public: bool = False
     request_examples: list[Any] | None = None
@@ -31,6 +32,7 @@ T = TypeVar("T", bound=Callable[..., Any])
 def webmethod(
     route: str | None = None,
     method: str | None = None,
+    level: str | None = "v1",
     public: bool | None = False,
     request_examples: list[Any] | None = None,
     response_examples: list[Any] | None = None,
@@ -54,6 +56,7 @@ def webmethod(
         func.__webmethod__ = WebMethod(  # type: ignore
             route=route,
             method=method,
+            level=level,
             public=public or False,
             request_examples=request_examples,
             response_examples=response_examples,

--- a/tests/unit/providers/nvidia/test_datastore.py
+++ b/tests/unit/providers/nvidia/test_datastore.py
@@ -67,7 +67,7 @@ def test_register_dataset(nvidia_adapter, run_async):
     _assert_request(
         mock_make_request,
         "POST",
-        "/v1/datasets",
+        "/v1beta/datasets",
         expected_json={
             "name": "test-dataset",
             "namespace": "default",
@@ -91,7 +91,7 @@ def test_unregister_dataset(nvidia_adapter, run_async):
     run_async(adapter.unregister_dataset(dataset_id))
 
     mock_make_request.assert_called_once()
-    _assert_request(mock_make_request, "DELETE", "/v1/datasets/default/test-dataset")
+    _assert_request(mock_make_request, "DELETE", "/v1beta/datasets/default/test-dataset")
 
 
 def test_register_dataset_with_custom_namespace_project(run_async):
@@ -130,7 +130,7 @@ def test_register_dataset_with_custom_namespace_project(run_async):
         _assert_request(
             mock_make_request,
             "POST",
-            "/v1/datasets",
+            "/v1beta/datasets",
             expected_json={
                 "name": "test-dataset",
                 "namespace": "custom-namespace",


### PR DESCRIPTION
# What does this PR do?

level the following APIs as v1beta:

1. eval: job scheduling is not implemented. Relies heavily on the datasetio API which is under development missing implementations of specific routes indicating the structure of those routes might change.
2. datasetio: used primarily by eval and training. Given that training is v1alpha, and eval is v1beta, datasetio is likely to change in structure as real usages of the API spin up. Register,unregister, and iter dataset is sparsely implemented meaning the shape of that route is likely to change.
3. telemetry: telemetry has been going through many changes. for example query_metrics was not even implemented until recently and had to change its shape to work. putting this in v1beta will allow us to fix functionality like OTEL, sqlite, etc. The routes themselves are set, but the structure might change a bit


FYI: all remaining APIs are `v1`, for now

relies on #3449 merging