### PR TITLE
feat: allow user to register model alias explicitly

### DIFF
--- a/benchmarking/k8s-benchmark/stack_run_config.yaml
+++ b/benchmarking/k8s-benchmark/stack_run_config.yaml
@@ -116,7 +116,8 @@ models:
   model_id: all-MiniLM-L6-v2
   provider_id: sentence-transformers
   model_type: embedding
-- model_id: ${env.INFERENCE_MODEL}
+- alias: ${env.INFERENCE_MODEL}
+  provider_model_id: ${env.INFERENCE_MODEL}
   provider_id: vllm-inference
   model_type: llm
 shields:

--- a/llama_stack/apis/models/models.py
+++ b/llama_stack/apis/models/models.py
@@ -10,8 +10,11 @@ from typing import Any, Literal, Protocol, runtime_checkable
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from llama_stack.apis.resource import Resource, ResourceType
+from llama_stack.log import get_logger
 from llama_stack.providers.utils.telemetry.trace_protocol import trace_protocol
 from llama_stack.schema_utils import json_schema_type, webmethod
+
+logger = get_logger(name=__name__, category="core")
 
 
 class CommonModelFields(BaseModel):
@@ -68,11 +71,30 @@ class Model(CommonModelFields, Resource):
 
 
 class ModelInput(CommonModelFields):
-    model_id: str
-    provider_id: str | None = None
+    """A model input for registering a model.
+
+    :param provider_model_id: The identifier of the model in the provider.
+    :param provider_id: The identifier of the provider.
+    :param model_type: The type of model to register.
+    :param model_id: The identifier of the model to register. The behavior of this field will change if model_id == provider_model_id. Use provider_model_id in such cases.
+    :param alias: Use model_id unless you want to use provider_model_id as an alias.
+    """
+
     provider_model_id: str | None = None
+    provider_id: str | None = None
     model_type: ModelType | None = ModelType.llm
     model_config = ConfigDict(protected_namespaces=())
+    model_id: str | None = None
+    alias: str | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.model_id is None and self.provider_model_id is None:
+            raise ValueError("provider_model_id must be provided")
+
+        if self.model_id == self.provider_model_id:
+            logger.warning(
+                "`model_id` is now optional. The behavior of this field will change if model_id == provider_model_id. Please remove `model_id` and use `provider_model_id` instead."
+            )
 
 
 class ListModelsResponse(BaseModel):

--- a/llama_stack/core/routing_tables/models.py
+++ b/llama_stack/core/routing_tables/models.py
@@ -69,11 +69,12 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
 
     async def register_model(
         self,
-        model_id: str,
+        model_id: str | None = None,
         provider_model_id: str | None = None,
         provider_id: str | None = None,
         metadata: dict[str, Any] | None = None,
         model_type: ModelType | None = None,
+        alias: str | None = None,
     ) -> Model:
         if provider_id is None:
             # If provider_id not specified, use the only provider if it supports this model
@@ -85,6 +86,14 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
                     "Use the provider_id as a prefix to disambiguate, e.g. 'provider_id/model_id'."
                 )
 
+        if model_id is None and provider_model_id is None:
+            raise ValueError("provider_model_id must be provided")
+
+        if model_id == provider_model_id:
+            logger.warning(
+                f"`model_id` is now optional. Please remove `model_id={model_id}` and use `provider_model_id={provider_model_id}` instead."
+            )
+
         provider_model_id = provider_model_id or model_id
         metadata = metadata or {}
         model_type = model_type or ModelType.llm
@@ -94,8 +103,9 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
         # an identifier different than provider_model_id implies it is an alias, so that
         # becomes the globally unique identifier. otherwise provider_model_ids can conflict,
         # so as a general rule we must use the provider_id to disambiguate.
-
-        if model_id != provider_model_id:
+        if alias:
+            identifier = alias
+        elif model_id != provider_model_id:
             identifier = model_id
         else:
             identifier = f"{provider_id}/{provider_model_id}"


### PR DESCRIPTION

# What does this PR do?

Context: https://github.com/llamastack/llama-stack/discussions/3483

This PR enables the registering `provider_model_id` as the model identifier without breaking backward compatibility.


## Test Plan
todo
