### PR TITLE
fix: Extend OpenAIResponseInput with MCP types

### DIFF
--- a/docs/_static/llama-stack-spec.html
+++ b/docs/_static/llama-stack-spec.html
@@ -8197,6 +8197,12 @@
                         "$ref": "#/components/schemas/OpenAIResponseOutputMessageFunctionToolCall"
                     },
                     {
+                        "$ref": "#/components/schemas/OpenAIResponseOutputMessageMCPCall"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OpenAIResponseOutputMessageMCPListTools"
+                    },
+                    {
                         "$ref": "#/components/schemas/OpenAIResponseInputFunctionToolCallOutput"
                     },
                     {
@@ -8841,6 +8847,129 @@
                 "title": "OpenAIResponseOutputMessageFunctionToolCall",
                 "description": "Function tool call output message for OpenAI responses."
             },
+            "OpenAIResponseOutputMessageMCPCall": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for this MCP call"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "mcp_call",
+                        "default": "mcp_call",
+                        "description": "Tool call type identifier, always \"mcp_call\""
+                    },
+                    "arguments": {
+                        "type": "string",
+                        "description": "JSON string containing the MCP call arguments"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the MCP method being called"
+                    },
+                    "server_label": {
+                        "type": "string",
+                        "description": "Label identifying the MCP server handling the call"
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "(Optional) Error message if the MCP call failed"
+                    },
+                    "output": {
+                        "type": "string",
+                        "description": "(Optional) Output result from the successful MCP call"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "type",
+                    "arguments",
+                    "name",
+                    "server_label"
+                ],
+                "title": "OpenAIResponseOutputMessageMCPCall",
+                "description": "Model Context Protocol (MCP) call output message for OpenAI responses."
+            },
+            "OpenAIResponseOutputMessageMCPListTools": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for this MCP list tools operation"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "mcp_list_tools",
+                        "default": "mcp_list_tools",
+                        "description": "Tool call type identifier, always \"mcp_list_tools\""
+                    },
+                    "server_label": {
+                        "type": "string",
+                        "description": "Label identifying the MCP server providing the tools"
+                    },
+                    "tools": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "input_schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "oneOf": [
+                                            {
+                                                "type": "null"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "object"
+                                            }
+                                        ]
+                                    },
+                                    "description": "JSON schema defining the tool's input parameters"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the tool"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "(Optional) Description of what the tool does"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "input_schema",
+                                "name"
+                            ],
+                            "title": "MCPListToolsTool",
+                            "description": "Tool definition returned by MCP list tools operation."
+                        },
+                        "description": "List of available tools provided by the MCP server"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id",
+                    "type",
+                    "server_label",
+                    "tools"
+                ],
+                "title": "OpenAIResponseOutputMessageMCPListTools",
+                "description": "MCP list tools output message containing available tools from an MCP server."
+            },
             "OpenAIResponseOutputMessageWebSearchToolCall": {
                 "type": "object",
                 "properties": {
@@ -9137,129 +9266,6 @@
                         "mcp_list_tools": "#/components/schemas/OpenAIResponseOutputMessageMCPListTools"
                     }
                 }
-            },
-            "OpenAIResponseOutputMessageMCPCall": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Unique identifier for this MCP call"
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "mcp_call",
-                        "default": "mcp_call",
-                        "description": "Tool call type identifier, always \"mcp_call\""
-                    },
-                    "arguments": {
-                        "type": "string",
-                        "description": "JSON string containing the MCP call arguments"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the MCP method being called"
-                    },
-                    "server_label": {
-                        "type": "string",
-                        "description": "Label identifying the MCP server handling the call"
-                    },
-                    "error": {
-                        "type": "string",
-                        "description": "(Optional) Error message if the MCP call failed"
-                    },
-                    "output": {
-                        "type": "string",
-                        "description": "(Optional) Output result from the successful MCP call"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "id",
-                    "type",
-                    "arguments",
-                    "name",
-                    "server_label"
-                ],
-                "title": "OpenAIResponseOutputMessageMCPCall",
-                "description": "Model Context Protocol (MCP) call output message for OpenAI responses."
-            },
-            "OpenAIResponseOutputMessageMCPListTools": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Unique identifier for this MCP list tools operation"
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "mcp_list_tools",
-                        "default": "mcp_list_tools",
-                        "description": "Tool call type identifier, always \"mcp_list_tools\""
-                    },
-                    "server_label": {
-                        "type": "string",
-                        "description": "Label identifying the MCP server providing the tools"
-                    },
-                    "tools": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "input_schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "oneOf": [
-                                            {
-                                                "type": "null"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "array"
-                                            },
-                                            {
-                                                "type": "object"
-                                            }
-                                        ]
-                                    },
-                                    "description": "JSON schema defining the tool's input parameters"
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "Name of the tool"
-                                },
-                                "description": {
-                                    "type": "string",
-                                    "description": "(Optional) Description of what the tool does"
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "input_schema",
-                                "name"
-                            ],
-                            "title": "MCPListToolsTool",
-                            "description": "Tool definition returned by MCP list tools operation."
-                        },
-                        "description": "List of available tools provided by the MCP server"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "id",
-                    "type",
-                    "server_label",
-                    "tools"
-                ],
-                "title": "OpenAIResponseOutputMessageMCPListTools",
-                "description": "MCP list tools output message containing available tools from an MCP server."
             },
             "OpenAIResponseContentPart": {
                 "oneOf": [

--- a/docs/_static/llama-stack-spec.yaml
+++ b/docs/_static/llama-stack-spec.yaml
@@ -5952,6 +5952,8 @@ components:
         - $ref: '#/components/schemas/OpenAIResponseOutputMessageWebSearchToolCall'
         - $ref: '#/components/schemas/OpenAIResponseOutputMessageFileSearchToolCall'
         - $ref: '#/components/schemas/OpenAIResponseOutputMessageFunctionToolCall'
+        - $ref: '#/components/schemas/OpenAIResponseOutputMessageMCPCall'
+        - $ref: '#/components/schemas/OpenAIResponseOutputMessageMCPListTools'
         - $ref: '#/components/schemas/OpenAIResponseInputFunctionToolCallOutput'
         - $ref: '#/components/schemas/OpenAIResponseMessage'
     "OpenAIResponseInputFunctionToolCallOutput":
@@ -6419,6 +6421,106 @@ components:
         OpenAIResponseOutputMessageFunctionToolCall
       description: >-
         Function tool call output message for OpenAI responses.
+    OpenAIResponseOutputMessageMCPCall:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this MCP call
+        type:
+          type: string
+          const: mcp_call
+          default: mcp_call
+          description: >-
+            Tool call type identifier, always "mcp_call"
+        arguments:
+          type: string
+          description: >-
+            JSON string containing the MCP call arguments
+        name:
+          type: string
+          description: Name of the MCP method being called
+        server_label:
+          type: string
+          description: >-
+            Label identifying the MCP server handling the call
+        error:
+          type: string
+          description: >-
+            (Optional) Error message if the MCP call failed
+        output:
+          type: string
+          description: >-
+            (Optional) Output result from the successful MCP call
+      additionalProperties: false
+      required:
+        - id
+        - type
+        - arguments
+        - name
+        - server_label
+      title: OpenAIResponseOutputMessageMCPCall
+      description: >-
+        Model Context Protocol (MCP) call output message for OpenAI responses.
+    OpenAIResponseOutputMessageMCPListTools:
+      type: object
+      properties:
+        id:
+          type: string
+          description: >-
+            Unique identifier for this MCP list tools operation
+        type:
+          type: string
+          const: mcp_list_tools
+          default: mcp_list_tools
+          description: >-
+            Tool call type identifier, always "mcp_list_tools"
+        server_label:
+          type: string
+          description: >-
+            Label identifying the MCP server providing the tools
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              input_schema:
+                type: object
+                additionalProperties:
+                  oneOf:
+                    - type: 'null'
+                    - type: boolean
+                    - type: number
+                    - type: string
+                    - type: array
+                    - type: object
+                description: >-
+                  JSON schema defining the tool's input parameters
+              name:
+                type: string
+                description: Name of the tool
+              description:
+                type: string
+                description: >-
+                  (Optional) Description of what the tool does
+            additionalProperties: false
+            required:
+              - input_schema
+              - name
+            title: MCPListToolsTool
+            description: >-
+              Tool definition returned by MCP list tools operation.
+          description: >-
+            List of available tools provided by the MCP server
+      additionalProperties: false
+      required:
+        - id
+        - type
+        - server_label
+        - tools
+      title: OpenAIResponseOutputMessageMCPListTools
+      description: >-
+        MCP list tools output message containing available tools from an MCP server.
     "OpenAIResponseOutputMessageWebSearchToolCall":
       type: object
       properties:
@@ -6652,106 +6754,6 @@ components:
           function_call: '#/components/schemas/OpenAIResponseOutputMessageFunctionToolCall'
           mcp_call: '#/components/schemas/OpenAIResponseOutputMessageMCPCall'
           mcp_list_tools: '#/components/schemas/OpenAIResponseOutputMessageMCPListTools'
-    OpenAIResponseOutputMessageMCPCall:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Unique identifier for this MCP call
-        type:
-          type: string
-          const: mcp_call
-          default: mcp_call
-          description: >-
-            Tool call type identifier, always "mcp_call"
-        arguments:
-          type: string
-          description: >-
-            JSON string containing the MCP call arguments
-        name:
-          type: string
-          description: Name of the MCP method being called
-        server_label:
-          type: string
-          description: >-
-            Label identifying the MCP server handling the call
-        error:
-          type: string
-          description: >-
-            (Optional) Error message if the MCP call failed
-        output:
-          type: string
-          description: >-
-            (Optional) Output result from the successful MCP call
-      additionalProperties: false
-      required:
-        - id
-        - type
-        - arguments
-        - name
-        - server_label
-      title: OpenAIResponseOutputMessageMCPCall
-      description: >-
-        Model Context Protocol (MCP) call output message for OpenAI responses.
-    OpenAIResponseOutputMessageMCPListTools:
-      type: object
-      properties:
-        id:
-          type: string
-          description: >-
-            Unique identifier for this MCP list tools operation
-        type:
-          type: string
-          const: mcp_list_tools
-          default: mcp_list_tools
-          description: >-
-            Tool call type identifier, always "mcp_list_tools"
-        server_label:
-          type: string
-          description: >-
-            Label identifying the MCP server providing the tools
-        tools:
-          type: array
-          items:
-            type: object
-            properties:
-              input_schema:
-                type: object
-                additionalProperties:
-                  oneOf:
-                    - type: 'null'
-                    - type: boolean
-                    - type: number
-                    - type: string
-                    - type: array
-                    - type: object
-                description: >-
-                  JSON schema defining the tool's input parameters
-              name:
-                type: string
-                description: Name of the tool
-              description:
-                type: string
-                description: >-
-                  (Optional) Description of what the tool does
-            additionalProperties: false
-            required:
-              - input_schema
-              - name
-            title: MCPListToolsTool
-            description: >-
-              Tool definition returned by MCP list tools operation.
-          description: >-
-            List of available tools provided by the MCP server
-      additionalProperties: false
-      required:
-        - id
-        - type
-        - server_label
-        - tools
-      title: OpenAIResponseOutputMessageMCPListTools
-      description: >-
-        MCP list tools output message containing available tools from an MCP server.
     OpenAIResponseContentPart:
       oneOf:
         - $ref: '#/components/schemas/OpenAIResponseContentPartOutputText'

--- a/docs/source/providers/agents/index.md
+++ b/docs/source/providers/agents/index.md
@@ -4,12 +4,12 @@
 
 Agents API for creating and interacting with agentic systems.
 
-    Main functionalities provided by this API:
-    - Create agents with specific instructions and ability to use tools.
-    - Interactions with agents are grouped into sessions ("threads"), and each interaction is called a "turn".
-    - Agents can be provided with various tools (see the ToolGroups and ToolRuntime APIs for more details).
-    - Agents can be provided with various shields (see the Safety API for more details).
-    - Agents can also use Memory to retrieve information from knowledge bases. See the RAG Tool and Vector IO APIs for more details.
+Main functionalities provided by this API:
+- Create agents with specific instructions and ability to use tools.
+- Interactions with agents are grouped into sessions ("threads"), and each interaction is called a "turn".
+- Agents can be provided with various tools (see the ToolGroups and ToolRuntime APIs for more details).
+- Agents can be provided with various shields (see the Safety API for more details).
+- Agents can also use Memory to retrieve information from knowledge bases. See the RAG Tool and Vector IO APIs for more details.
 
 This section contains documentation for all available providers for the **agents** API.
 

--- a/docs/source/providers/batches/index.md
+++ b/docs/source/providers/batches/index.md
@@ -3,15 +3,15 @@
 ## Overview
 
 The Batches API enables efficient processing of multiple requests in a single operation,
-    particularly useful for processing large datasets, batch evaluation workflows, and
-    cost-effective inference at scale.
+particularly useful for processing large datasets, batch evaluation workflows, and
+cost-effective inference at scale.
 
-    The API is designed to allow use of openai client libraries for seamless integration.
+The API is designed to allow use of openai client libraries for seamless integration.
 
-    This API provides the following extensions:
-     - idempotent batch creation
+This API provides the following extensions:
+ - idempotent batch creation
 
-    Note: This API is currently under active development and may undergo changes.
+Note: This API is currently under active development and may undergo changes.
 
 This section contains documentation for all available providers for the **batches** API.
 

--- a/docs/source/providers/inference/index.md
+++ b/docs/source/providers/inference/index.md
@@ -4,9 +4,9 @@
 
 Llama Stack Inference API for generating completions, chat completions, and embeddings.
 
-    This API provides the raw interface to the underlying models. Two kinds of models are supported:
-    - LLM models: these models generate "raw" and "chat" (conversational) completions.
-    - Embedding models: these models generate embeddings to be used for semantic search.
+This API provides the raw interface to the underlying models. Two kinds of models are supported:
+- LLM models: these models generate "raw" and "chat" (conversational) completions.
+- Embedding models: these models generate embeddings to be used for semantic search.
 
 This section contains documentation for all available providers for the **inference** API.
 

--- a/llama_stack/apis/agents/openai_responses.py
+++ b/llama_stack/apis/agents/openai_responses.py
@@ -724,6 +724,8 @@ OpenAIResponseInput = Annotated[
     OpenAIResponseOutputMessageWebSearchToolCall
     | OpenAIResponseOutputMessageFileSearchToolCall
     | OpenAIResponseOutputMessageFunctionToolCall
+    | OpenAIResponseOutputMessageMCPCall
+    | OpenAIResponseOutputMessageMCPListTools
     | OpenAIResponseInputFunctionToolCallOutput
     |
     # Fallback to the generic message type as a last resort


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
When posting chained resposnes with MCP tools, llamastack fails to validate OpenAIResponseInput.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

Using llamastack 0.2.22, post 3-5 chained responses with a simple mcp tool enabled, a validation error will show up as follows:
```
18:15:05.181 [ERROR] Error executing endpoint route='/v1/openai/v1/responses'  
           method='post': 15 validation errors for OpenAIResponseObjectWithInput                                                                        
           input.1.OpenAIResponseOutputMessageWebSearchToolCall.status                                                                                  
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseOutputMessageWebSearchToolCall.type                                                                                    
             Input should be 'web_search_call'                                                                                                          
               For further information visit https://errors.pydantic.dev/2.11/v/literal_error                                                           
           input.1.OpenAIResponseOutputMessageFileSearchToolCall.queries                                                                                
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseOutputMessageFileSearchToolCall.status                                                                                 
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseOutputMessageFileSearchToolCall.type                                                                                   
             Input should be 'file_search_call'                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/literal_error                                                           
           input.1.OpenAIResponseOutputMessageFunctionToolCall.call_id                                                                                  
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseOutputMessageFunctionToolCall.name                                                                                     
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseOutputMessageFunctionToolCall.arguments                                                                                
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseOutputMessageFunctionToolCall.type                                                                                     
             Input should be 'function_call'                                                                                                            
               For further information visit https://errors.pydantic.dev/2.11/v/literal_error                                                           
           input.1.OpenAIResponseInputFunctionToolCallOutput.call_id                                                                                    
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseInputFunctionToolCallOutput.output                                                                                     
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseInputFunctionToolCallOutput.type                                                                                       
             Input should be 'function_call_output'                                                                                                     
               For further information visit https://errors.pydantic.dev/2.11/v/literal_error                                                           
           input.1.OpenAIResponseMessage.content                                                                                                        
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseMessage.role                                                                                                           
             Field required }, input_type=dict]                                                                                                         
               For further information visit https://errors.pydantic.dev/2.11/v/missing                                                                 
           input.1.OpenAIResponseMessage.type                                                                                                           
             Input should be 'message'
```

Once the MCP types are added to OpenAIResponseMessage, this works as expected both with openai and llamastack's responses client.  An image with this PR can be found in quay.io/yuvalturg/lls-yuvi:0.2.22
