### PR TITLE
chore: remove duplicate AnthropicProviderDataValidator

### DIFF
--- a/llama_stack/providers/remote/inference/anthropic/__init__.py
+++ b/llama_stack/providers/remote/inference/anthropic/__init__.py
@@ -4,13 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from pydantic import BaseModel
-
 from .config import AnthropicConfig
-
-
-class AnthropicProviderDataValidator(BaseModel):
-    anthropic_api_key: str | None = None
 
 
 async def get_adapter_impl(config: AnthropicConfig, _deps):


### PR DESCRIPTION
# What does this PR do?

removes the duplicate AnthropicProviderDataValidator

the active one is in config.py

## Test Plan

ci