### PR TITLE
fix: docs deployment URL

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -9,8 +9,8 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 const config: Config = {
   title: 'Llama Stack',
   tagline: 'The open-source framework for building generative AI applications',
-  url: 'https://reluctantfuturist.github.io',
-  baseUrl: '/llama-stack/',
+  url: 'https://llamastack.github.io',
+  baseUrl: '/',
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",


### PR DESCRIPTION
# What does this PR do?
Fixes Llama Stack docs deployment URL

## Test Plan
```
npm run gen-api-docs all
npm run build
```
successfully builds the documentation 