### PR TITLE
fix: ensure ModelRegistryHelper init for together and fireworks

### DIFF
--- a/llama_stack/providers/remote/inference/fireworks/fireworks.py
+++ b/llama_stack/providers/remote/inference/fireworks/fireworks.py
@@ -64,6 +64,7 @@ class FireworksInferenceAdapter(OpenAIMixin, ModelRegistryHelper, Inference, Nee
     }
 
     def __init__(self, config: FireworksImplConfig) -> None:
+        ModelRegistryHelper.__init__(self)
         self.config = config
         self.allowed_models = config.allowed_models
 

--- a/llama_stack/providers/remote/inference/together/together.py
+++ b/llama_stack/providers/remote/inference/together/together.py
@@ -70,6 +70,7 @@ class TogetherInferenceAdapter(OpenAIMixin, ModelRegistryHelper, Inference, Need
     }
 
     def __init__(self, config: TogetherImplConfig) -> None:
+        ModelRegistryHelper.__init__(self)
         self.config = config
         self.allowed_models = config.allowed_models
         self._model_cache: dict[str, Model] = {}


### PR DESCRIPTION
# What does this PR do?

address -
```
ERROR    2025-09-26 10:44:29,450 main:527 core::server: Error creating app: 'FireworksInferenceAdapter' object has no attribute
         'alias_to_provider_id_map'
```

## Test Plan

manual startup w/ valid together & fireworks api keys