### PR TITLE
chore: skip nvidia datastore tests when nvidia datastore is not enabled

### DIFF
--- a/tests/integration/providers/nvidia/test_datastore.py
+++ b/tests/integration/providers/nvidia/test_datastore.py
@@ -14,6 +14,13 @@ from . import skip_in_github_actions
 # LLAMA_STACK_CONFIG="nvidia" pytest -v tests/integration/providers/nvidia/test_datastore.py
 
 
+@pytest.fixture(autouse=True)
+def skip_if_no_nvidia_provider(llama_stack_client):
+    provider_types = {p.provider_type for p in llama_stack_client.providers.list() if p.api == "datasetio"}
+    if "remote::nvidia" not in provider_types:
+        pytest.skip("datasetio=remote::nvidia provider not configured, skipping")
+
+
 # nvidia provider only
 @skip_in_github_actions
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do?

the nvidia datastore tests were running when the datastore was not configured. they would always fail.

this introduces a skip when the nvidia datastore is not configured.


## Test Plan

ci