### PR TITLE
feat(api): implement v1beta leveling, and additional alpha

### DIFF
--- a/docs/static/llama-stack-spec.html
+++ b/docs/static/llama-stack-spec.html
@@ -40,6 +40,53 @@
         }
     ],
     "paths": {
+        "/v1beta/datasetio/append-rows/{dataset_id}": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "DatasetIO"
+                ],
+                "summary": "Append rows to a dataset.",
+                "description": "Append rows to a dataset.",
+                "parameters": [
+                    {
+                        "name": "dataset_id",
+                        "in": "path",
+                        "description": "The ID of the dataset to append the rows to.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AppendRowsRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/v1/datasetio/append-rows/{dataset_id}": {
             "post": {
                 "responses": {
@@ -1522,6 +1569,85 @@
                 ]
             }
         },
+        "/v1beta/datasets/{dataset_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A Dataset.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dataset"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Datasets"
+                ],
+                "summary": "Get a dataset by its ID.",
+                "description": "Get a dataset by its ID.",
+                "parameters": [
+                    {
+                        "name": "dataset_id",
+                        "in": "path",
+                        "description": "The ID of the dataset to get.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Datasets"
+                ],
+                "summary": "Unregister a dataset by its ID.",
+                "description": "Unregister a dataset by its ID.",
+                "parameters": [
+                    {
+                        "name": "dataset_id",
+                        "in": "path",
+                        "description": "The ID of the dataset to unregister.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/v1/datasets/{dataset_id}": {
             "get": {
                 "responses": {
@@ -1838,6 +1964,59 @@
                 ]
             }
         },
+        "/v1alpha/telemetry/traces/{trace_id}/spans/{span_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A Span.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Span"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Get a span by its ID.",
+                "description": "Get a span by its ID.",
+                "parameters": [
+                    {
+                        "name": "trace_id",
+                        "in": "path",
+                        "description": "The ID of the trace to get the span from.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "span_id",
+                        "in": "path",
+                        "description": "The ID of the span to get.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/v1/telemetry/traces/{trace_id}/spans/{span_id}": {
             "get": {
                 "responses": {
@@ -1889,6 +2068,60 @@
                         }
                     }
                 ]
+            }
+        },
+        "/v1alpha/telemetry/spans/{span_id}/tree": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "A QuerySpanTreeResponse.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QuerySpanTreeResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Get a span tree by its ID.",
+                "description": "Get a span tree by its ID.",
+                "parameters": [
+                    {
+                        "name": "span_id",
+                        "in": "path",
+                        "description": "The ID of the span to get the tree from.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GetSpanTreeRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
             }
         },
         "/v1/telemetry/spans/{span_id}/tree": {
@@ -2060,6 +2293,50 @@
                         "name": "toolgroup_id",
                         "in": "path",
                         "description": "The ID of the tool group to unregister.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/v1alpha/telemetry/traces/{trace_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A Trace.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trace"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Get a trace by its ID.",
+                "description": "Get a trace by its ID.",
+                "parameters": [
+                    {
+                        "name": "trace_id",
+                        "in": "path",
+                        "description": "The ID of the trace to get.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2629,6 +2906,68 @@
                     },
                     "required": true
                 }
+            }
+        },
+        "/v1beta/datasetio/iterrows/{dataset_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A PaginatedResponse.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "DatasetIO"
+                ],
+                "summary": "Get a paginated list of rows from a dataset.",
+                "description": "Get a paginated list of rows from a dataset.\nUses offset-based pagination where:\n- start_index: The starting index (0-based). If None, starts from beginning.\n- limit: Number of items to return. If None or -1, returns all items.\n\nThe response includes:\n- data: List of items for the current page.\n- has_more: Whether there are more items available after this set.",
+                "parameters": [
+                    {
+                        "name": "dataset_id",
+                        "in": "path",
+                        "description": "The ID of the dataset to get the rows from.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "start_index",
+                        "in": "query",
+                        "description": "Index into dataset for the first row to get. Get all rows if None.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The number of rows to get.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ]
             }
         },
         "/v1/datasetio/iterrows/{dataset_id}": {
@@ -3306,6 +3645,82 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/OpenaiChatCompletionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/v1beta/datasets": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A ListDatasetsResponse.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListDatasetsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Datasets"
+                ],
+                "summary": "List all datasets.",
+                "description": "List all datasets.",
+                "parameters": []
+            },
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "A Dataset.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dataset"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Datasets"
+                ],
+                "summary": "Register a new dataset.",
+                "description": "Register a new dataset.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RegisterDatasetRequest"
                             }
                         }
                     },
@@ -5333,6 +5748,60 @@
                 }
             }
         },
+        "/v1alpha/telemetry/metrics/{metric_name}": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "A QueryMetricsResponse.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QueryMetricsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Query metrics.",
+                "description": "Query metrics.",
+                "parameters": [
+                    {
+                        "name": "metric_name",
+                        "in": "path",
+                        "description": "The name of the metric to query.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/QueryMetricsRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/v1/telemetry/metrics/{metric_name}": {
             "post": {
                 "responses": {
@@ -5387,6 +5856,50 @@
                 }
             }
         },
+        "/v1alpha/telemetry/spans": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "A QuerySpansResponse.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QuerySpansResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Query spans.",
+                "description": "Query spans.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/QuerySpansRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/v1/telemetry/spans": {
             "post": {
                 "responses": {
@@ -5424,6 +5937,50 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/QuerySpansRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/v1alpha/telemetry/traces": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "A QueryTracesResponse.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QueryTracesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Query traces.",
+                "description": "Query traces.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/QueryTracesRequest"
                             }
                         }
                     },
@@ -5785,6 +6342,43 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/RunShieldRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/v1alpha/telemetry/spans/export": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest400"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/TooManyRequests429"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError500"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultError"
+                    }
+                },
+                "tags": [
+                    "Telemetry"
+                ],
+                "summary": "Save spans to a dataset.",
+                "description": "Save spans to a dataset.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SaveSpansToDatasetRequest"
                             }
                         }
                     },

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -10,6 +10,39 @@ info:
 servers:
   - url: http://any-hosted-llama-stack.com
 paths:
+  /v1beta/datasetio/append-rows/{dataset_id}:
+    post:
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - DatasetIO
+      summary: Append rows to a dataset.
+      description: Append rows to a dataset.
+      parameters:
+        - name: dataset_id
+          in: path
+          description: >-
+            The ID of the dataset to append the rows to.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppendRowsRequest'
+        required: true
   /v1/datasetio/append-rows/{dataset_id}:
     post:
       responses:
@@ -1063,6 +1096,61 @@ paths:
           required: true
           schema:
             type: string
+  /v1beta/datasets/{dataset_id}:
+    get:
+      responses:
+        '200':
+          description: A Dataset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dataset'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Datasets
+      summary: Get a dataset by its ID.
+      description: Get a dataset by its ID.
+      parameters:
+        - name: dataset_id
+          in: path
+          description: The ID of the dataset to get.
+          required: true
+          schema:
+            type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Datasets
+      summary: Unregister a dataset by its ID.
+      description: Unregister a dataset by its ID.
+      parameters:
+        - name: dataset_id
+          in: path
+          description: The ID of the dataset to unregister.
+          required: true
+          schema:
+            type: string
   /v1/datasets/{dataset_id}:
     get:
       responses:
@@ -1286,6 +1374,43 @@ paths:
           required: true
           schema:
             type: string
+  /v1alpha/telemetry/traces/{trace_id}/spans/{span_id}:
+    get:
+      responses:
+        '200':
+          description: A Span.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Span'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Get a span by its ID.
+      description: Get a span by its ID.
+      parameters:
+        - name: trace_id
+          in: path
+          description: >-
+            The ID of the trace to get the span from.
+          required: true
+          schema:
+            type: string
+        - name: span_id
+          in: path
+          description: The ID of the span to get.
+          required: true
+          schema:
+            type: string
   /v1/telemetry/traces/{trace_id}/spans/{span_id}:
     get:
       responses:
@@ -1323,6 +1448,42 @@ paths:
           required: true
           schema:
             type: string
+  /v1alpha/telemetry/spans/{span_id}/tree:
+    post:
+      responses:
+        '200':
+          description: A QuerySpanTreeResponse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuerySpanTreeResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Get a span tree by its ID.
+      description: Get a span tree by its ID.
+      parameters:
+        - name: span_id
+          in: path
+          description: The ID of the span to get the tree from.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSpanTreeRequest'
+        required: true
   /v1/telemetry/spans/{span_id}/tree:
     post:
       responses:
@@ -1441,6 +1602,36 @@ paths:
         - name: toolgroup_id
           in: path
           description: The ID of the tool group to unregister.
+          required: true
+          schema:
+            type: string
+  /v1alpha/telemetry/traces/{trace_id}:
+    get:
+      responses:
+        '200':
+          description: A Trace.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Trace'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Get a trace by its ID.
+      description: Get a trace by its ID.
+      parameters:
+        - name: trace_id
+          in: path
+          description: The ID of the trace to get.
           required: true
           schema:
             type: string
@@ -1847,6 +2038,65 @@ paths:
             schema:
               $ref: '#/components/schemas/InvokeToolRequest'
         required: true
+  /v1beta/datasetio/iterrows/{dataset_id}:
+    get:
+      responses:
+        '200':
+          description: A PaginatedResponse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - DatasetIO
+      summary: >-
+        Get a paginated list of rows from a dataset.
+      description: >-
+        Get a paginated list of rows from a dataset.
+
+        Uses offset-based pagination where:
+
+        - start_index: The starting index (0-based). If None, starts from beginning.
+
+        - limit: Number of items to return. If None or -1, returns all items.
+
+
+        The response includes:
+
+        - data: List of items for the current page.
+
+        - has_more: Whether there are more items available after this set.
+      parameters:
+        - name: dataset_id
+          in: path
+          description: >-
+            The ID of the dataset to get the rows from.
+          required: true
+          schema:
+            type: string
+        - name: start_index
+          in: query
+          description: >-
+            Index into dataset for the first row to get. Get all rows if None.
+          required: false
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of rows to get.
+          required: false
+          schema:
+            type: integer
   /v1/datasetio/iterrows/{dataset_id}:
     get:
       responses:
@@ -2345,6 +2595,59 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/OpenaiChatCompletionRequest'
+        required: true
+  /v1beta/datasets:
+    get:
+      responses:
+        '200':
+          description: A ListDatasetsResponse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDatasetsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Datasets
+      summary: List all datasets.
+      description: List all datasets.
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: A Dataset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dataset'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Datasets
+      summary: Register a new dataset.
+      description: Register a new dataset.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterDatasetRequest'
         required: true
   /v1/datasets:
     get:
@@ -3834,6 +4137,42 @@ paths:
             schema:
               $ref: '#/components/schemas/QueryChunksRequest'
         required: true
+  /v1alpha/telemetry/metrics/{metric_name}:
+    post:
+      responses:
+        '200':
+          description: A QueryMetricsResponse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryMetricsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Query metrics.
+      description: Query metrics.
+      parameters:
+        - name: metric_name
+          in: path
+          description: The name of the metric to query.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryMetricsRequest'
+        required: true
   /v1/telemetry/metrics/{metric_name}:
     post:
       responses:
@@ -3870,6 +4209,36 @@ paths:
             schema:
               $ref: '#/components/schemas/QueryMetricsRequest'
         required: true
+  /v1alpha/telemetry/spans:
+    post:
+      responses:
+        '200':
+          description: A QuerySpansResponse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuerySpansResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Query spans.
+      description: Query spans.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpansRequest'
+        required: true
   /v1/telemetry/spans:
     post:
       responses:
@@ -3899,6 +4268,36 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/QuerySpansRequest'
+        required: true
+  /v1alpha/telemetry/traces:
+    post:
+      responses:
+        '200':
+          description: A QueryTracesResponse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryTracesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Query traces.
+      description: Query traces.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryTracesRequest'
         required: true
   /v1/telemetry/traces:
     post:
@@ -4159,6 +4558,32 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RunShieldRequest'
+        required: true
+  /v1alpha/telemetry/spans/export:
+    post:
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest400'
+        '429':
+          $ref: >-
+            #/components/responses/TooManyRequests429
+        '500':
+          $ref: >-
+            #/components/responses/InternalServerError500
+        default:
+          $ref: '#/components/responses/DefaultError'
+      tags:
+        - Telemetry
+      summary: Save spans to a dataset.
+      description: Save spans to a dataset.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveSpansToDatasetRequest'
         required: true
   /v1/telemetry/spans/export:
     post:

--- a/llama_stack/apis/datasetio/datasetio.py
+++ b/llama_stack/apis/datasetio/datasetio.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from llama_stack.apis.common.responses import PaginatedResponse
 from llama_stack.apis.datasets import Dataset
-from llama_stack.apis.version import LLAMA_STACK_API_V1
+from llama_stack.apis.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1BETA
 from llama_stack.schema_utils import webmethod
 
 
@@ -21,7 +21,8 @@ class DatasetIO(Protocol):
     # keeping for aligning with inference/safety, but this is not used
     dataset_store: DatasetStore
 
-    @webmethod(route="/datasetio/iterrows/{dataset_id:path}", method="GET", level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasetio/iterrows/{dataset_id:path}", method="GET", deprecated=True, level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasetio/iterrows/{dataset_id:path}", method="GET", level=LLAMA_STACK_API_V1BETA)
     async def iterrows(
         self,
         dataset_id: str,
@@ -45,7 +46,10 @@ class DatasetIO(Protocol):
         """
         ...
 
-    @webmethod(route="/datasetio/append-rows/{dataset_id:path}", method="POST", level=LLAMA_STACK_API_V1)
+    @webmethod(
+        route="/datasetio/append-rows/{dataset_id:path}", method="POST", deprecated=True, level=LLAMA_STACK_API_V1
+    )
+    @webmethod(route="/datasetio/append-rows/{dataset_id:path}", method="POST", level=LLAMA_STACK_API_V1BETA)
     async def append_rows(self, dataset_id: str, rows: list[dict[str, Any]]) -> None:
         """Append rows to a dataset.
 

--- a/llama_stack/apis/datasets/datasets.py
+++ b/llama_stack/apis/datasets/datasets.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Literal, Protocol
 from pydantic import BaseModel, Field
 
 from llama_stack.apis.resource import Resource, ResourceType
-from llama_stack.apis.version import LLAMA_STACK_API_V1
+from llama_stack.apis.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1BETA
 from llama_stack.schema_utils import json_schema_type, register_schema, webmethod
 
 
@@ -146,7 +146,8 @@ class ListDatasetsResponse(BaseModel):
 
 
 class Datasets(Protocol):
-    @webmethod(route="/datasets", method="POST", level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets", method="POST", deprecated=True, level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets", method="POST", level=LLAMA_STACK_API_V1BETA)
     async def register_dataset(
         self,
         purpose: DatasetPurpose,
@@ -215,7 +216,8 @@ class Datasets(Protocol):
         """
         ...
 
-    @webmethod(route="/datasets/{dataset_id:path}", method="GET", level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets/{dataset_id:path}", method="GET", deprecated=True, level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets/{dataset_id:path}", method="GET", level=LLAMA_STACK_API_V1BETA)
     async def get_dataset(
         self,
         dataset_id: str,
@@ -227,7 +229,8 @@ class Datasets(Protocol):
         """
         ...
 
-    @webmethod(route="/datasets", method="GET", level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets", method="GET", deprecated=True, level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets", method="GET", level=LLAMA_STACK_API_V1BETA)
     async def list_datasets(self) -> ListDatasetsResponse:
         """List all datasets.
 
@@ -235,7 +238,8 @@ class Datasets(Protocol):
         """
         ...
 
-    @webmethod(route="/datasets/{dataset_id:path}", method="DELETE", level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets/{dataset_id:path}", method="DELETE", deprecated=True, level=LLAMA_STACK_API_V1)
+    @webmethod(route="/datasets/{dataset_id:path}", method="DELETE", level=LLAMA_STACK_API_V1BETA)
     async def unregister_dataset(
         self,
         dataset_id: str,

--- a/llama_stack/apis/telemetry/telemetry.py
+++ b/llama_stack/apis/telemetry/telemetry.py
@@ -16,7 +16,7 @@ from typing import (
 
 from pydantic import BaseModel, Field
 
-from llama_stack.apis.version import LLAMA_STACK_API_V1
+from llama_stack.apis.version import LLAMA_STACK_API_V1, LLAMA_STACK_API_V1ALPHA
 from llama_stack.models.llama.datatypes import Primitive
 from llama_stack.schema_utils import json_schema_type, register_schema, webmethod
 
@@ -426,7 +426,14 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/traces", method="POST", required_scope=REQUIRED_SCOPE, level=LLAMA_STACK_API_V1)
+    @webmethod(
+        route="/telemetry/traces",
+        method="POST",
+        required_scope=REQUIRED_SCOPE,
+        deprecated=True,
+        level=LLAMA_STACK_API_V1,
+    )
+    @webmethod(route="/telemetry/traces", method="POST", required_scope=REQUIRED_SCOPE, level=LLAMA_STACK_API_V1ALPHA)
     async def query_traces(
         self,
         attribute_filters: list[QueryCondition] | None = None,
@@ -445,7 +452,17 @@ class Telemetry(Protocol):
         ...
 
     @webmethod(
-        route="/telemetry/traces/{trace_id:path}", method="GET", required_scope=REQUIRED_SCOPE, level=LLAMA_STACK_API_V1
+        route="/telemetry/traces/{trace_id:path}",
+        method="GET",
+        required_scope=REQUIRED_SCOPE,
+        deprecated=True,
+        level=LLAMA_STACK_API_V1,
+    )
+    @webmethod(
+        route="/telemetry/traces/{trace_id:path}",
+        method="GET",
+        required_scope=REQUIRED_SCOPE,
+        level=LLAMA_STACK_API_V1ALPHA,
     )
     async def get_trace(self, trace_id: str) -> Trace:
         """Get a trace by its ID.
@@ -459,7 +476,14 @@ class Telemetry(Protocol):
         route="/telemetry/traces/{trace_id:path}/spans/{span_id:path}",
         method="GET",
         required_scope=REQUIRED_SCOPE,
+        deprecated=True,
         level=LLAMA_STACK_API_V1,
+    )
+    @webmethod(
+        route="/telemetry/traces/{trace_id:path}/spans/{span_id:path}",
+        method="GET",
+        required_scope=REQUIRED_SCOPE,
+        level=LLAMA_STACK_API_V1ALPHA,
     )
     async def get_span(self, trace_id: str, span_id: str) -> Span:
         """Get a span by its ID.
@@ -473,8 +497,15 @@ class Telemetry(Protocol):
     @webmethod(
         route="/telemetry/spans/{span_id:path}/tree",
         method="POST",
+        deprecated=True,
         required_scope=REQUIRED_SCOPE,
         level=LLAMA_STACK_API_V1,
+    )
+    @webmethod(
+        route="/telemetry/spans/{span_id:path}/tree",
+        method="POST",
+        required_scope=REQUIRED_SCOPE,
+        level=LLAMA_STACK_API_V1ALPHA,
     )
     async def get_span_tree(
         self,
@@ -491,7 +522,14 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/spans", method="POST", required_scope=REQUIRED_SCOPE, level=LLAMA_STACK_API_V1)
+    @webmethod(
+        route="/telemetry/spans",
+        method="POST",
+        required_scope=REQUIRED_SCOPE,
+        deprecated=True,
+        level=LLAMA_STACK_API_V1,
+    )
+    @webmethod(route="/telemetry/spans", method="POST", required_scope=REQUIRED_SCOPE, level=LLAMA_STACK_API_V1ALPHA)
     async def query_spans(
         self,
         attribute_filters: list[QueryCondition],
@@ -507,7 +545,8 @@ class Telemetry(Protocol):
         """
         ...
 
-    @webmethod(route="/telemetry/spans/export", method="POST", level=LLAMA_STACK_API_V1)
+    @webmethod(route="/telemetry/spans/export", method="POST", deprecated=True, level=LLAMA_STACK_API_V1)
+    @webmethod(route="/telemetry/spans/export", method="POST", level=LLAMA_STACK_API_V1ALPHA)
     async def save_spans_to_dataset(
         self,
         attribute_filters: list[QueryCondition],
@@ -525,7 +564,17 @@ class Telemetry(Protocol):
         ...
 
     @webmethod(
-        route="/telemetry/metrics/{metric_name}", method="POST", required_scope=REQUIRED_SCOPE, level=LLAMA_STACK_API_V1
+        route="/telemetry/metrics/{metric_name}",
+        method="POST",
+        required_scope=REQUIRED_SCOPE,
+        deprecated=True,
+        level=LLAMA_STACK_API_V1,
+    )
+    @webmethod(
+        route="/telemetry/metrics/{metric_name}",
+        method="POST",
+        required_scope=REQUIRED_SCOPE,
+        level=LLAMA_STACK_API_V1ALPHA,
     )
     async def query_metrics(
         self,


### PR DESCRIPTION
# What does this PR do?

level the following APIs, keeping their old routes around as well until 0.4.0

1. datasetio to v1beta:  used primarily by eval and training. Given that training is v1alpha, and eval is v1alpha, datasetio is likely to change in structure as real usages of the API spin up. Register,unregister, and iter dataset is sparsely implemented meaning the shape of that route is likely to change.

2. telemetry to v1alpha: telemetry has been going through many changes. for example query_metrics was not even implemented until recently and had to change its shape to work. putting this in v1beta will allow us to fix functionality like OTEL, sqlite, etc. The routes themselves are set, but the structure might change a bit

