### PR TITLE
fix: Remove deprecated user param in OpenAIResponseObject

### DIFF
--- a/docs/static/llama-stack-spec.html
+++ b/docs/static/llama-stack-spec.html
@@ -9456,10 +9456,6 @@
                     "truncation": {
                         "type": "string",
                         "description": "(Optional) Truncation strategy applied to the response"
-                    },
-                    "user": {
-                        "type": "string",
-                        "description": "(Optional) User identifier associated with the request"
                     }
                 },
                 "additionalProperties": false,
@@ -13593,10 +13589,6 @@
                     "truncation": {
                         "type": "string",
                         "description": "(Optional) Truncation strategy applied to the response"
-                    },
-                    "user": {
-                        "type": "string",
-                        "description": "(Optional) User identifier associated with the request"
                     },
                     "input": {
                         "type": "array",

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -6884,10 +6884,6 @@ components:
           type: string
           description: >-
             (Optional) Truncation strategy applied to the response
-        user:
-          type: string
-          description: >-
-            (Optional) User identifier associated with the request
       additionalProperties: false
       required:
         - created_at
@@ -10082,10 +10078,6 @@ components:
           type: string
           description: >-
             (Optional) Truncation strategy applied to the response
-        user:
-          type: string
-          description: >-
-            (Optional) User identifier associated with the request
         input:
           type: array
           items:

--- a/llama_stack/apis/agents/openai_responses.py
+++ b/llama_stack/apis/agents/openai_responses.py
@@ -336,7 +336,6 @@ class OpenAIResponseObject(BaseModel):
     :param text: Text formatting configuration for the response
     :param top_p: (Optional) Nucleus sampling parameter used for generation
     :param truncation: (Optional) Truncation strategy applied to the response
-    :param user: (Optional) User identifier associated with the request
     """
 
     created_at: int
@@ -354,7 +353,6 @@ class OpenAIResponseObject(BaseModel):
     text: OpenAIResponseText = OpenAIResponseText(format=OpenAIResponseTextFormat(type="text"))
     top_p: float | None = None
     truncation: str | None = None
-    user: str | None = None
 
 
 @json_schema_type

--- a/llama_stack/ui/app/logs/responses/[id]/page.tsx
+++ b/llama_stack/ui/app/logs/responses/[id]/page.tsx
@@ -41,7 +41,6 @@ export default function ResponseDetailPage() {
       temperature: responseData.temperature,
       top_p: responseData.top_p,
       truncation: responseData.truncation,
-      user: responseData.user,
     };
   };
 

--- a/llama_stack/ui/components/responses/responses-table.tsx
+++ b/llama_stack/ui/components/responses/responses-table.tsx
@@ -43,7 +43,6 @@ const convertResponseListData = (
     temperature: responseData.temperature,
     top_p: responseData.top_p,
     truncation: responseData.truncation,
-    user: responseData.user,
   };
 };
 


### PR DESCRIPTION
# What does this PR do?
Just removing the deprecated User param in `OpenAIResponseObject`

## Test Plan
CI
