### PR TITLE
fix: Raising an error message to the user when registering an existing provider.

### DIFF
--- a/llama_stack/core/store/registry.py
+++ b/llama_stack/core/store/registry.py
@@ -98,7 +98,10 @@ class DiskDistributionRegistry(DistributionRegistry):
         existing_obj = await self.get(obj.type, obj.identifier)
         # dont register if the object's providerid already exists
         if existing_obj and existing_obj.provider_id == obj.provider_id:
-            return False
+            raise ValueError(
+                f"Model '{obj.identifier}' is already registered with provider '{obj.provider_id}'. "
+                f"Please unregister the existing model first before registering a new one."
+            )
 
         await self.kvstore.set(
             KEY_FORMAT.format(type=obj.type, identifier=obj.identifier),

--- a/tests/unit/registry/test_registry.py
+++ b/tests/unit/registry/test_registry.py
@@ -125,8 +125,12 @@ async def test_duplicate_provider_registration(cached_disk_dist_registry):
         provider_resource_id="test_vector_db_2",
         provider_id="baz",  # Same provider_id
     )
-    await cached_disk_dist_registry.register(duplicate_vector_db)
 
+    # Now we expect a ValueError to be raised for duplicate registration
+    with pytest.raises(ValueError, match=r".*already registered.*"):
+        await cached_disk_dist_registry.register(duplicate_vector_db)
+
+    # Verify the original registration is still intact
     result = await cached_disk_dist_registry.get("vector_db", "test_vector_db_2")
     assert result is not None
     assert result.embedding_model == original_vector_db.embedding_model  # Original values preserved


### PR DESCRIPTION
When the user wants to change the attributes (which could include model name, dimensions,...etc) of an already registered provider, they will get an error message asking that they first unregister the provider before registering a new one.

# What does this PR do?
This PR updated the register function to raise an error to the user when they attempt to register a provider that was already registered asking them to un-register the existing provider first.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[2313] -->

## Test Plan
Tested the change with /tests/unit/registry/test_registry.py
