### PR TITLE
fix: log level

### DIFF
--- a/llama_stack/log.py
+++ b/llama_stack/log.py
@@ -247,7 +247,16 @@ def get_logger(
         _category_levels.update(parse_yaml_config(config))
 
     logger = logging.getLogger(name)
-    logger.setLevel(_category_levels.get(category, DEFAULT_LOG_LEVEL))
+    if category in _category_levels:
+        log_level = _category_levels[category]
+    else:
+        root_category = category.split("::")[0]
+        if root_category in _category_levels:
+            log_level = _category_levels[root_category]
+        else:
+            log_level = _category_levels.get("root", DEFAULT_LOG_LEVEL)
+            logging.warning(f"Unknown logging category: {category}. Falling back to default 'root' level: {log_level}")
+    logger.setLevel(log_level)
     return logging.LoggerAdapter(logger, {"category": category})
 
 


### PR DESCRIPTION

# What does this PR do?
- categories like "core::server" is not recognized so it's level is not set by 'all=debug'
- removed spammy telemetry debug logging

## Test Plan
test server launched with LLAMA_STACK_LOGGING='all=debug'
