### PR TITLE
fix: responses <> chat completion input conversion

### DIFF
--- a/llama_stack/apis/agents/openai_responses.py
+++ b/llama_stack/apis/agents/openai_responses.py
@@ -888,6 +888,10 @@ class OpenAIResponseObjectWithInput(OpenAIResponseObject):
 
     input: list[OpenAIResponseInput]
 
+    def to_response_object(self) -> OpenAIResponseObject:
+        """Convert to OpenAIResponseObject by excluding input field."""
+        return OpenAIResponseObject(**{k: v for k, v in self.model_dump().items() if k != "input"})
+
 
 @json_schema_type
 class ListOpenAIResponseObject(BaseModel):

--- a/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -43,6 +43,7 @@ from llama_stack.apis.inference import (
     OpenAIChatCompletion,
     OpenAIChatCompletionToolCall,
     OpenAIChoice,
+    OpenAIMessageParam,
 )
 from llama_stack.log import get_logger
 
@@ -103,6 +104,8 @@ class StreamingResponseOrchestrator:
         self.sequence_number = 0
         # Store MCP tool mapping that gets built during tool processing
         self.mcp_tool_to_server: dict[str, OpenAIResponseInputToolMCP] = {}
+        # Track final messages after all tool executions
+        self.final_messages: list[OpenAIMessageParam] = []
 
     async def create_response(self) -> AsyncIterator[OpenAIResponseObjectStream]:
         # Initialize output messages
@@ -191,6 +194,8 @@ class StreamingResponseOrchestrator:
                 break
 
             messages = next_turn_messages
+
+        self.final_messages = messages.copy() + [current_response.choices[0].message]
 
         # Create final response
         final_response = OpenAIResponseObject(

--- a/llama_stack/providers/utils/responses/responses_store.py
+++ b/llama_stack/providers/utils/responses/responses_store.py
@@ -17,6 +17,7 @@ from llama_stack.apis.agents.openai_responses import (
     OpenAIResponseObject,
     OpenAIResponseObjectWithInput,
 )
+from llama_stack.apis.inference import OpenAIMessageParam
 from llama_stack.core.datatypes import AccessRule, ResponsesStoreConfig
 from llama_stack.core.utils.config_dirs import RUNTIME_BASE_DIR
 from llama_stack.log import get_logger
@@ -26,6 +27,19 @@ from ..sqlstore.authorized_sqlstore import AuthorizedSqlStore
 from ..sqlstore.sqlstore import SqliteSqlStoreConfig, SqlStoreConfig, SqlStoreType, sqlstore_impl
 
 logger = get_logger(name=__name__, category="responses_store")
+
+
+class _OpenAIResponseObjectWithInputAndMessages(OpenAIResponseObjectWithInput):
+    """Internal class for storing responses with chat completion messages.
+
+    This extends the public OpenAIResponseObjectWithInput with messages field
+    for internal storage. The messages field is not exposed in the public API.
+
+    The messages field is optional for backward compatibility with responses
+    stored before this feature was added.
+    """
+
+    messages: list[OpenAIMessageParam] | None = None
 
 
 class ResponsesStore:
@@ -54,7 +68,9 @@ class ResponsesStore:
         self.enable_write_queue = self.sql_store_config.type != SqlStoreType.sqlite
 
         # Async write queue and worker control
-        self._queue: asyncio.Queue[tuple[OpenAIResponseObject, list[OpenAIResponseInput]]] | None = None
+        self._queue: (
+            asyncio.Queue[tuple[OpenAIResponseObject, list[OpenAIResponseInput], list[OpenAIMessageParam]]] | None
+        ) = None
         self._worker_tasks: list[asyncio.Task[Any]] = []
         self._max_write_queue_size: int = config.max_write_queue_size
         self._num_writers: int = max(1, config.num_writers)
@@ -100,18 +116,21 @@ class ResponsesStore:
             await self._queue.join()
 
     async def store_response_object(
-        self, response_object: OpenAIResponseObject, input: list[OpenAIResponseInput]
+        self,
+        response_object: OpenAIResponseObject,
+        input: list[OpenAIResponseInput],
+        messages: list[OpenAIMessageParam],
     ) -> None:
         if self.enable_write_queue:
             if self._queue is None:
                 raise ValueError("Responses store is not initialized")
             try:
-                self._queue.put_nowait((response_object, input))
+                self._queue.put_nowait((response_object, input, messages))
             except asyncio.QueueFull:
                 logger.warning(f"Write queue full; adding response id={getattr(response_object, 'id', '<unknown>')}")
-                await self._queue.put((response_object, input))
+                await self._queue.put((response_object, input, messages))
         else:
-            await self._write_response_object(response_object, input)
+            await self._write_response_object(response_object, input, messages)
 
     async def _worker_loop(self) -> None:
         assert self._queue is not None
@@ -120,22 +139,26 @@ class ResponsesStore:
                 item = await self._queue.get()
             except asyncio.CancelledError:
                 break
-            response_object, input = item
+            response_object, input, messages = item
             try:
-                await self._write_response_object(response_object, input)
+                await self._write_response_object(response_object, input, messages)
             except Exception as e:  # noqa: BLE001
                 logger.error(f"Error writing response object: {e}")
             finally:
                 self._queue.task_done()
 
     async def _write_response_object(
-        self, response_object: OpenAIResponseObject, input: list[OpenAIResponseInput]
+        self,
+        response_object: OpenAIResponseObject,
+        input: list[OpenAIResponseInput],
+        messages: list[OpenAIMessageParam],
     ) -> None:
         if self.sql_store is None:
             raise ValueError("Responses store is not initialized")
 
         data = response_object.model_dump()
         data["input"] = [input_item.model_dump() for input_item in input]
+        data["messages"] = [msg.model_dump() for msg in messages]
 
         await self.sql_store.insert(
             "openai_responses",
@@ -188,7 +211,7 @@ class ResponsesStore:
             last_id=data[-1].id if data else "",
         )
 
-    async def get_response_object(self, response_id: str) -> OpenAIResponseObjectWithInput:
+    async def get_response_object(self, response_id: str) -> _OpenAIResponseObjectWithInputAndMessages:
         """
         Get a response object with automatic access control checking.
         """
@@ -205,7 +228,7 @@ class ResponsesStore:
             # This provides security by not revealing whether the record exists
             raise ValueError(f"Response with id {response_id} not found") from None
 
-        return OpenAIResponseObjectWithInput(**row["response_object"])
+        return _OpenAIResponseObjectWithInputAndMessages(**row["response_object"])
 
     async def delete_response_object(self, response_id: str) -> OpenAIDeleteResponseObject:
         if not self.sql_store:
@@ -241,8 +264,8 @@ class ResponsesStore:
         if before and after:
             raise ValueError("Cannot specify both 'before' and 'after' parameters")
 
-        response_with_input = await self.get_response_object(response_id)
-        items = response_with_input.input
+        response_with_input_and_messages = await self.get_response_object(response_id)
+        items = response_with_input_and_messages.input
 
         if order == Order.desc:
             items = list(reversed(items))

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses.py
@@ -22,7 +22,6 @@ from llama_stack.apis.agents.openai_responses import (
     OpenAIResponseInputToolFunction,
     OpenAIResponseInputToolWebSearch,
     OpenAIResponseMessage,
-    OpenAIResponseObjectWithInput,
     OpenAIResponseOutputMessageContentOutputText,
     OpenAIResponseOutputMessageMCPCall,
     OpenAIResponseOutputMessageWebSearchToolCall,
@@ -45,7 +44,10 @@ from llama_stack.core.datatypes import ResponsesStoreConfig
 from llama_stack.providers.inline.agents.meta_reference.responses.openai_responses import (
     OpenAIResponsesImpl,
 )
-from llama_stack.providers.utils.responses.responses_store import ResponsesStore
+from llama_stack.providers.utils.responses.responses_store import (
+    ResponsesStore,
+    _OpenAIResponseObjectWithInputAndMessages,
+)
 from llama_stack.providers.utils.sqlstore.sqlstore import SqliteSqlStoreConfig
 from tests.unit.providers.agents.meta_reference.fixtures import load_chat_completion_fixture
 
@@ -498,13 +500,6 @@ async def test_create_openai_response_with_multiple_messages(openai_responses_im
             assert isinstance(inference_messages[i], OpenAIDeveloperMessageParam)
 
 
-async def test_prepend_previous_response_none(openai_responses_impl):
-    """Test prepending no previous response to a new response."""
-
-    input = await openai_responses_impl._prepend_previous_response("fake_input", None)
-    assert input == "fake_input"
-
-
 async def test_prepend_previous_response_basic(openai_responses_impl, mock_responses_store):
     """Test prepending a basic previous response to a new response."""
 
@@ -519,7 +514,7 @@ async def test_prepend_previous_response_basic(openai_responses_impl, mock_respo
         status="completed",
         role="assistant",
     )
-    previous_response = OpenAIResponseObjectWithInput(
+    previous_response = _OpenAIResponseObjectWithInputAndMessages(
         created_at=1,
         id="resp_123",
         model="fake_model",
@@ -527,10 +522,11 @@ async def test_prepend_previous_response_basic(openai_responses_impl, mock_respo
         status="completed",
         text=OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
         input=[input_item_message],
+        messages=[OpenAIUserMessageParam(content="fake_previous_input")],
     )
     mock_responses_store.get_response_object.return_value = previous_response
 
-    input = await openai_responses_impl._prepend_previous_response("fake_input", "resp_123")
+    input = await openai_responses_impl._prepend_previous_response("fake_input", previous_response)
 
     assert len(input) == 3
     # Check for previous input
@@ -561,7 +557,7 @@ async def test_prepend_previous_response_web_search(openai_responses_impl, mock_
         status="completed",
         role="assistant",
     )
-    response = OpenAIResponseObjectWithInput(
+    response = _OpenAIResponseObjectWithInputAndMessages(
         created_at=1,
         id="resp_123",
         model="fake_model",
@@ -569,11 +565,12 @@ async def test_prepend_previous_response_web_search(openai_responses_impl, mock_
         status="completed",
         text=OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
         input=[input_item_message],
+        messages=[OpenAIUserMessageParam(content="test input")],
     )
     mock_responses_store.get_response_object.return_value = response
 
     input_messages = [OpenAIResponseMessage(content="fake_input", role="user")]
-    input = await openai_responses_impl._prepend_previous_response(input_messages, "resp_123")
+    input = await openai_responses_impl._prepend_previous_response(input_messages, response)
 
     assert len(input) == 4
     # Check for previous input
@@ -608,7 +605,7 @@ async def test_prepend_previous_response_mcp_tool_call(openai_responses_impl, mo
         status="completed",
         role="assistant",
     )
-    response = OpenAIResponseObjectWithInput(
+    response = _OpenAIResponseObjectWithInputAndMessages(
         created_at=1,
         id="resp_123",
         model="fake_model",
@@ -616,11 +613,12 @@ async def test_prepend_previous_response_mcp_tool_call(openai_responses_impl, mo
         status="completed",
         text=OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
         input=[input_item_message],
+        messages=[OpenAIUserMessageParam(content="test input")],
     )
     mock_responses_store.get_response_object.return_value = response
 
     input_messages = [OpenAIResponseMessage(content="fake_input", role="user")]
-    input = await openai_responses_impl._prepend_previous_response(input_messages, "resp_123")
+    input = await openai_responses_impl._prepend_previous_response(input_messages, response)
 
     assert len(input) == 4
     # Check for previous input
@@ -724,7 +722,7 @@ async def test_create_openai_response_with_instructions_and_previous_response(
         status="completed",
         role="assistant",
     )
-    response = OpenAIResponseObjectWithInput(
+    response = _OpenAIResponseObjectWithInputAndMessages(
         created_at=1,
         id="resp_123",
         model="fake_model",
@@ -732,6 +730,10 @@ async def test_create_openai_response_with_instructions_and_previous_response(
         status="completed",
         text=OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
         input=[input_item_message],
+        messages=[
+            OpenAIUserMessageParam(content="Name some towns in Ireland"),
+            OpenAIAssistantMessageParam(content="Galway, Longford, Sligo"),
+        ],
     )
     mock_responses_store.get_response_object.return_value = response
 
@@ -817,7 +819,7 @@ async def test_responses_store_list_input_items_logic():
         OpenAIResponseMessage(id="msg_4", content="Fourth message", role="user"),
     ]
 
-    response_with_input = OpenAIResponseObjectWithInput(
+    response_with_input = _OpenAIResponseObjectWithInputAndMessages(
         id="resp_123",
         model="test_model",
         created_at=1234567890,
@@ -826,6 +828,7 @@ async def test_responses_store_list_input_items_logic():
         output=[],
         text=OpenAIResponseText(format=(OpenAIResponseTextFormat(type="text"))),
         input=input_items,
+        messages=[OpenAIUserMessageParam(content="First message")],
     )
 
     # Mock the get_response_object method to return our test data
@@ -886,7 +889,7 @@ async def test_store_response_uses_rehydrated_input_with_previous_response(
     rather than just the original input when previous_response_id is provided."""
 
     # Setup - Create a previous response that should be included in the stored input
-    previous_response = OpenAIResponseObjectWithInput(
+    previous_response = _OpenAIResponseObjectWithInputAndMessages(
         id="resp-previous-123",
         object="response",
         created_at=1234567890,
@@ -904,6 +907,10 @@ async def test_store_response_uses_rehydrated_input_with_previous_response(
                 role="assistant",
                 content=[OpenAIResponseOutputMessageContentOutputText(text="2+2 equals 4.")],
             )
+        ],
+        messages=[
+            OpenAIUserMessageParam(content="What is 2+2?"),
+            OpenAIAssistantMessageParam(content="2+2 equals 4."),
         ],
     )
 

--- a/tests/unit/utils/responses/test_responses_store.py
+++ b/tests/unit/utils/responses/test_responses_store.py
@@ -14,6 +14,7 @@ from llama_stack.apis.agents.openai_responses import (
     OpenAIResponseInput,
     OpenAIResponseObject,
 )
+from llama_stack.apis.inference import OpenAIMessageParam, OpenAIUserMessageParam
 from llama_stack.providers.utils.responses.responses_store import ResponsesStore
 from llama_stack.providers.utils.sqlstore.sqlstore import SqliteSqlStoreConfig
 
@@ -44,6 +45,11 @@ def create_test_response_input(content: str, input_id: str) -> OpenAIResponseInp
     )
 
 
+def create_test_messages(content: str) -> list[OpenAIMessageParam]:
+    """Helper to create test messages for chat completion."""
+    return [OpenAIUserMessageParam(content=content)]
+
+
 async def test_responses_store_pagination_basic():
     """Test basic pagination functionality for responses store."""
     with TemporaryDirectory() as tmp_dir:
@@ -65,7 +71,8 @@ async def test_responses_store_pagination_basic():
         for response_id, timestamp in test_data:
             response = create_test_response_object(response_id, timestamp)
             input_list = [create_test_response_input(f"Input for {response_id}", f"input-{response_id}")]
-            await store.store_response_object(response, input_list)
+            messages = create_test_messages(f"Input for {response_id}")
+            await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()
@@ -111,7 +118,8 @@ async def test_responses_store_pagination_ascending():
         for response_id, timestamp in test_data:
             response = create_test_response_object(response_id, timestamp)
             input_list = [create_test_response_input(f"Input for {response_id}", f"input-{response_id}")]
-            await store.store_response_object(response, input_list)
+            messages = create_test_messages(f"Input for {response_id}")
+            await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()
@@ -149,7 +157,8 @@ async def test_responses_store_pagination_with_model_filter():
         for response_id, timestamp, model in test_data:
             response = create_test_response_object(response_id, timestamp, model)
             input_list = [create_test_response_input(f"Input for {response_id}", f"input-{response_id}")]
-            await store.store_response_object(response, input_list)
+            messages = create_test_messages(f"Input for {response_id}")
+            await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()
@@ -199,7 +208,8 @@ async def test_responses_store_pagination_no_limit():
         for response_id, timestamp in test_data:
             response = create_test_response_object(response_id, timestamp)
             input_list = [create_test_response_input(f"Input for {response_id}", f"input-{response_id}")]
-            await store.store_response_object(response, input_list)
+            messages = create_test_messages(f"Input for {response_id}")
+            await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()
@@ -222,7 +232,8 @@ async def test_responses_store_get_response_object():
         # Store a test response
         response = create_test_response_object("test-resp", int(time.time()))
         input_list = [create_test_response_input("Test input content", "input-test-resp")]
-        await store.store_response_object(response, input_list)
+        messages = create_test_messages("Test input content")
+        await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()
@@ -255,7 +266,8 @@ async def test_responses_store_input_items_pagination():
             create_test_response_input("Fourth input", "input-4"),
             create_test_response_input("Fifth input", "input-5"),
         ]
-        await store.store_response_object(response, input_list)
+        messages = create_test_messages("First input")
+        await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()
@@ -335,7 +347,8 @@ async def test_responses_store_input_items_before_pagination():
             create_test_response_input("Fourth input", "before-4"),
             create_test_response_input("Fifth input", "before-5"),
         ]
-        await store.store_response_object(response, input_list)
+        messages = create_test_messages("First input")
+        await store.store_response_object(response, input_list, messages)
 
         # Wait for all queued writes to complete
         await store.flush()


### PR DESCRIPTION
# What does this PR do?

closes #3268
closes #3498

When resuming from previous response ID, currently we attempt to convert from the stored responses input to chat completion messages, which is not always possible, e.g. for tool calls where some data is lost once converted from chat completion message to repsonses input format.

This PR stores the chat completion messages that correspond to the _last_ call to chat completion, which is sufficient to be resumed from in the next responses API call, where we load these saved messages and skip conversion entirely.

Separate issue to optimize storage: https://github.com/llamastack/llama-stack/issues/3646

## Test Plan
existing CI tests
